### PR TITLE
Bunch of improvements + add product dialog

### DIFF
--- a/Bots/GretaBot.cs
+++ b/Bots/GretaBot.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
+using CoreBot.Utilities;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Schema;
@@ -14,8 +15,6 @@ namespace CoreBot.Bots
         private readonly Dialog Dialog;
         private readonly BotState _conversationState;
         private readonly BotState _userState;
-
-        private const string sameCardMsg = "Don't use the same Submit Card twice. If you want to submit new data ask for the Card again.";
 
         public GretaBot(ConversationState conversationState, UserState userState, T dialog)
         {
@@ -38,7 +37,7 @@ namespace CoreBot.Bots
 
                 if (conversationData.DisabledCards.ContainsKey((string)jobject["id"]))
                 {
-                    await turnContext.SendActivityAsync(MessageFactory.Text(sameCardMsg), cancellationToken);
+                    await turnContext.SendActivityAsync(MessageFactory.Text(CardUtils.sameCardMsg), cancellationToken);
                 }
                 else
                 {

--- a/Cards/confirmOrderCard.json
+++ b/Cards/confirmOrderCard.json
@@ -120,14 +120,16 @@
             {
               "type": "Action.Submit",
               "data": {
-                "action": "confirmOrder"
+                "action": "confirmOrder",
+                "id": "submitButton1"
               },
               "title": "Confirm Order"
             },
             {
               "type": "Action.Submit",
               "data": {
-                "action": "cancelOrder"
+                "action": "cancelOrder",
+                "id": "submitButton2"
               },
               "title": "Cancel Order"
             }

--- a/Cards/productInfoFillingCard.json
+++ b/Cards/productInfoFillingCard.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.0",
+  "body": [
+    {
+      "type": "TextBlock",
+      "size": "Medium",
+      "weight": "Bolder",
+      "text": "Product Info filling Card",
+      "horizontalAlignment": "Center"
+    },
+    {
+      "type": "Input.Text",
+      "placeholder": "Product Name",
+      "style": "text",
+      "maxLength": 0,
+      "id": "ProdName"
+    },
+    {
+      "type": "Input.Text",
+      "placeholder": "Product Title",
+      "style": "Url",
+      "maxLength": 0,
+      "id": "ProdTitle"
+    },
+    {
+      "type": "Input.Text",
+      "placeholder": "Description",
+      "isMultiline": true,
+      "style": "Tel",
+      "maxLength": 0,
+      "id": "ProdDesc"
+    }
+  ],
+  "actions": [
+    {
+      "type": "Action.ShowCard",
+      "title": "Add Store Info",
+      "card": {
+        "type": "AdaptiveCard",
+        "body": [
+          {
+            "type": "Input.Text",
+            "placeholder": "(optional) VitrosepStore URL",
+            "style": "text",
+            "maxLength": 0,
+            "id": "StoreURL"
+          },
+          {
+            "type": "Input.Text",
+            "placeholder": "(optional) Image URL",
+            "style": "text",
+            "maxLength": 0,
+            "id": "ImageURL"
+          }
+
+        ],
+        "actions": [
+          {
+            "type": "Action.Submit",
+            "title": "OK"
+          }
+        ],
+        "$schema": "http://adaptivecards.io/schemas/adaptive-card.json"
+      }
+    },
+    {
+      "type": "Action.Submit",
+      "title": "Submit",
+      "data": {
+        "id": "submitButton"
+      }
+    }
+  ]
+}

--- a/Cards/productInfoFillingCard.json
+++ b/Cards/productInfoFillingCard.json
@@ -59,7 +59,10 @@
         "actions": [
           {
             "type": "Action.Submit",
-            "title": "OK"
+            "title": "OK",
+            "data": {
+              "id": "submitButton2"
+            }
           }
         ],
         "$schema": "http://adaptivecards.io/schemas/adaptive-card.json"
@@ -69,7 +72,7 @@
       "type": "Action.Submit",
       "title": "Submit",
       "data": {
-        "id": "submitButton"
+        "id": "submitButton1"
       }
     }
   ]

--- a/ConversationData.cs
+++ b/ConversationData.cs
@@ -7,10 +7,12 @@ namespace CoreBot
 {
     public class ConversationData
     {
-        public NodeDecisio currentNode { get; set; }
+        public NodeDecisio CurrentNode { get; set; }
 
-        public bool startedTechSupport { get; set; } = false;
+        public bool StartedTechSupport { get; set; } = false;
 
-        public NodeDecisio rootNode { get; set; }
+        public NodeDecisio RootNode { get; set; }
+
+        public Dictionary<string, DateTime> DisabledCards { get; } = new Dictionary<string,DateTime>();
     }
 }

--- a/CoreBot.csproj
+++ b/CoreBot.csproj
@@ -25,6 +25,6 @@
   </ItemGroup>
 
   <Import Project="PostDeployScripts\IncludeSources.targets" Condition="Exists('PostDeployScripts\IncludeSources.targets')" />
-  <ProjectExtensions><VisualStudio><UserProperties appsettings_1json__JsonSchema="" /></VisualStudio></ProjectExtensions>
+  <ProjectExtensions><VisualStudio><UserProperties appsettings_1json__JsonSchema="" cards_4productinfofillingcard_1json__JsonSchema="" /></VisualStudio></ProjectExtensions>
 
 </Project>

--- a/Dialogs/AddProductInfoDialog.cs
+++ b/Dialogs/AddProductInfoDialog.cs
@@ -1,10 +1,13 @@
 ﻿using AdaptiveCards;
+using CoreBot.Utilities;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
+using System.Data.SqlClient;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,18 +16,25 @@ namespace CoreBot.Dialogs
 {
     public class AddProductInfoDialog : CancelAndHelpDialog
     {
+        private const string Preview = "Do you want to preview the Product you just added?";
         private readonly IConfiguration Configuration;
+
         public AddProductInfoDialog(UserState userState, IConfiguration configuration) : base(nameof(AddProductInfoDialog), userState)
         {
             AddDialog(new TextPrompt(nameof(TextPrompt), ValidateCardInputAsync));
+            AddDialog(new ConfirmPrompt(nameof(ConfirmPrompt)));
             AddDialog(new WaterfallDialog(nameof(WaterfallDialog), new WaterfallStep[]
             {
                 CheckPermissionStepAsync,
-                PromptCardStepAsync
+                PromptCardStepAsync,
+                ProcessResultStepAsync,
+                PromptProductCardAsync
             }));
 
+            InitialDialogId = nameof(WaterfallDialog);
+
             // VITROSEP and Superusers only
-            PermissionLevel = 1;
+            PermissionLevel = 5;
             Configuration = configuration;
         }
 
@@ -39,7 +49,7 @@ namespace CoreBot.Dialogs
                 Attachments = new List<Attachment>() {
                         new Attachment()
                         {
-                            Content = card,
+                            Content = JsonConvert.DeserializeObject(JsonConvert.SerializeObject(card)),
                             ContentType = "application/vnd.microsoft.card.adaptive"
                         }
                     },
@@ -57,7 +67,54 @@ namespace CoreBot.Dialogs
 
         private async Task<DialogTurnResult> ProcessResultStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
+            var jobject = JObject.Parse((string)stepContext.Result);
+            var productInfo = new ProductInfo
+            {
+                Name = (string)jobject["ProdName"],
+                Title = (string)jobject["ProdTitle"],
+                DisplayText = (string)jobject["ProdDesc"]
+            };
 
+            if (!string.IsNullOrEmpty((string)jobject["StoreURL"]))
+            {
+                productInfo.StoreURL = (string)jobject["StoreURL"];
+            }
+            if (!string.IsNullOrEmpty((string)jobject["ImageURL"]))
+            {
+                productInfo.ImageURL = (string)jobject["ImageURL"];
+            }
+
+            stepContext.Values["ProductInfo"] = productInfo;
+            int connection = SendProductInfoToDb(productInfo);
+
+            if (connection < 0)
+            {
+                await stepContext.Context.SendActivityAsync("There was an error sending the Product to the DataBase.");
+                return await stepContext.EndDialogAsync(null, cancellationToken);
+            }
+            else
+            {
+                await stepContext.Context.SendActivityAsync("The product was added to the DataBase successfully");
+                return await stepContext.PromptAsync(nameof(ConfirmPrompt),
+                    new PromptOptions { Prompt = MessageFactory.Text(Preview) }, cancellationToken);
+            }
+        }
+
+        private async Task<DialogTurnResult> PromptProductCardAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        {
+            if ((bool)stepContext.Result)
+            {
+                var productInfo = (ProductInfo)stepContext.Values["ProductInfo"];
+
+                var attachment = CardUtils.CreateCardFromProductInfo(productInfo);
+                var adaptiveCard = stepContext.Context.Activity.CreateReply();
+
+                adaptiveCard.Attachments = new List<Attachment>() { attachment };
+                await stepContext.Context.SendActivityAsync(adaptiveCard, cancellationToken);
+            }
+
+            await stepContext.Context.SendActivityAsync(MessageFactory.Text(whatElse), cancellationToken);
+            return await stepContext.EndDialogAsync(null,cancellationToken);
         }
 
 
@@ -81,6 +138,41 @@ namespace CoreBot.Dialogs
                 return await Task.FromResult(false);
             }
             return await Task.FromResult(true);
+        }
+
+
+        private int SendProductInfoToDb(ProductInfo productInfo)
+        {
+            bool storeEmpty = string.IsNullOrEmpty(productInfo.StoreURL);
+            bool imageEmpty = string.IsNullOrEmpty(productInfo.ImageURL);
+            string query = $@"INSERT INTO [dbo].[ProductInfo]
+                VALUES (@ProductName, @ProductDesc, {(storeEmpty ? "NULL" : "@StoreURL")}, {(imageEmpty ? "NULL" : "@ImageURL")}, @ProductTitle)";
+
+            string connectionString = Configuration.GetConnectionString("DefaultConnection");
+
+            using (SqlConnection connection = new SqlConnection(connectionString))
+            {
+                SqlCommand command = new SqlCommand(query, connection);
+                command.Parameters.AddWithValue("@ProductName",productInfo.Name);
+                command.Parameters.AddWithValue("@ProductDesc", productInfo.DisplayText);
+
+                if(!storeEmpty)
+                    command.Parameters.AddWithValue("@StoreURL", productInfo.StoreURL);
+
+                if(!imageEmpty)
+                    command.Parameters.AddWithValue("@ImageURL", productInfo.ImageURL);
+
+                command.Parameters.AddWithValue("@ProductTitle", productInfo.Title);
+
+                connection.Open();
+
+                int result = command.ExecuteNonQuery();
+
+                connection.Close();
+                command.Dispose();
+
+                return result;
+            }
         }
     }
 }

--- a/Dialogs/AddProductInfoDialog.cs
+++ b/Dialogs/AddProductInfoDialog.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace CoreBot.Dialogs
+{
+    public class AddProductInfoDialog : CancelAndHelpDialog
+    {
+        public AddProductInfoDialog(UserState userState) : base(nameof(AddProductInfoDialog), userState)
+        {
+            AddDialog(new TextPrompt(nameof(TextPrompt)));
+            AddDialog(new WaterfallDialog(nameof(WaterfallDialog), new WaterfallStep[]
+            {
+                CheckPermissionStepAsync,
+            }));
+
+            PermissionLevel = 1;
+        }
+    }
+}

--- a/Dialogs/AddProductInfoDialog.cs
+++ b/Dialogs/AddProductInfoDialog.cs
@@ -2,12 +2,10 @@
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Schema;
-using Newtonsoft.Json;
+using Microsoft.Extensions.Configuration;
 using Newtonsoft.Json.Linq;
-using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -15,9 +13,10 @@ namespace CoreBot.Dialogs
 {
     public class AddProductInfoDialog : CancelAndHelpDialog
     {
-        public AddProductInfoDialog(UserState userState) : base(nameof(AddProductInfoDialog), userState)
+        private readonly IConfiguration Configuration;
+        public AddProductInfoDialog(UserState userState, IConfiguration configuration) : base(nameof(AddProductInfoDialog), userState)
         {
-            AddDialog(new TextPrompt(nameof(TextPrompt), ValidateQuantityAsync));
+            AddDialog(new TextPrompt(nameof(TextPrompt), ValidateCardInputAsync));
             AddDialog(new WaterfallDialog(nameof(WaterfallDialog), new WaterfallStep[]
             {
                 CheckPermissionStepAsync,
@@ -26,6 +25,7 @@ namespace CoreBot.Dialogs
 
             // VITROSEP and Superusers only
             PermissionLevel = 1;
+            Configuration = configuration;
         }
 
         private async Task<DialogTurnResult> PromptCardStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
@@ -61,7 +61,7 @@ namespace CoreBot.Dialogs
         }
 
 
-        private async Task<bool> ValidateQuantityAsync(PromptValidatorContext<string> promptContext, CancellationToken cancellationToken)
+        private async Task<bool> ValidateCardInputAsync(PromptValidatorContext<string> promptContext, CancellationToken cancellationToken)
         {
             var jobject = JObject.Parse(promptContext.Context.Activity.Text);
 

--- a/Dialogs/AddProductInfoDialog.cs
+++ b/Dialogs/AddProductInfoDialog.cs
@@ -1,8 +1,14 @@
-﻿using Microsoft.Bot.Builder;
+﻿using AdaptiveCards;
+using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Schema;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace CoreBot.Dialogs
@@ -11,13 +17,70 @@ namespace CoreBot.Dialogs
     {
         public AddProductInfoDialog(UserState userState) : base(nameof(AddProductInfoDialog), userState)
         {
-            AddDialog(new TextPrompt(nameof(TextPrompt)));
+            AddDialog(new TextPrompt(nameof(TextPrompt), ValidateQuantityAsync));
             AddDialog(new WaterfallDialog(nameof(WaterfallDialog), new WaterfallStep[]
             {
                 CheckPermissionStepAsync,
+                PromptCardStepAsync
             }));
 
+            // VITROSEP and Superusers only
             PermissionLevel = 1;
+        }
+
+        private async Task<DialogTurnResult> PromptCardStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        {
+            string[] paths = { ".", "Cards", "productInfoFillingCard.json" };
+            var cardJson = File.ReadAllText(Path.Combine(paths));
+            var card = AdaptiveCard.FromJson(cardJson).Card;
+
+            var activity = new Activity
+            {
+                Attachments = new List<Attachment>() {
+                        new Attachment()
+                        {
+                            Content = card,
+                            ContentType = "application/vnd.microsoft.card.adaptive"
+                        }
+                    },
+                Type = ActivityTypes.Message
+            };
+
+            var opts = new PromptOptions
+            {
+                Prompt = activity,
+                RetryPrompt = activity
+            };
+
+            return await stepContext.PromptAsync(nameof(TextPrompt), opts);
+        }
+
+        private async Task<DialogTurnResult> ProcessResultStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        {
+
+        }
+
+
+        private async Task<bool> ValidateQuantityAsync(PromptValidatorContext<string> promptContext, CancellationToken cancellationToken)
+        {
+            var jobject = JObject.Parse(promptContext.Context.Activity.Text);
+
+            if (string.IsNullOrEmpty((string)jobject["ProdName"]))
+            {
+                await promptContext.Context.SendActivityAsync(MessageFactory.Text("Product name can't be empty!"));
+                return await Task.FromResult(false);
+            }
+            else if (string.IsNullOrEmpty((string)jobject["ProdTitle"]))
+            {
+                await promptContext.Context.SendActivityAsync(MessageFactory.Text("Product title can't be empty!"));
+                return await Task.FromResult(false);
+            }
+            else if (string.IsNullOrEmpty((string)jobject["ProdDesc"]))
+            {
+                await promptContext.Context.SendActivityAsync(MessageFactory.Text("Product description can't be empty!"));
+                return await Task.FromResult(false);
+            }
+            return await Task.FromResult(true);
         }
     }
 }

--- a/Dialogs/AskUserInfoDialog.cs
+++ b/Dialogs/AskUserInfoDialog.cs
@@ -41,7 +41,7 @@ namespace CoreBot.Dialogs
 
             var userProfile = await _profileAccessor.GetAsync(stepContext.Context, () => new UserProfile());
 
-            userProfile.name = name;
+            userProfile.Name = name;
 
             stepContext.Values["profile"] = userProfile;
 
@@ -68,8 +68,8 @@ namespace CoreBot.Dialogs
             var company = (string)stepContext.Result;
             var userProfile = (UserProfile)stepContext.Values["profile"];
 
-            userProfile.askedForUserInfo = true;
-            userProfile.company = company;
+            userProfile.AskedForUserInfo = true;
+            userProfile.Company = company;
             await _profileAccessor.SetAsync(stepContext.Context, userProfile, cancellationToken);
 
             return await stepContext.PromptAsync(nameof(TextPrompt), new PromptOptions { Prompt = MessageFactory.Text(finishMsg) }, cancellationToken);

--- a/Dialogs/CancelAndHelpDialog.cs
+++ b/Dialogs/CancelAndHelpDialog.cs
@@ -16,6 +16,7 @@ namespace CoreBot.Dialogs
         private const string noPermission = "Sorry, you don't have privilege to use this functionality.";
         protected readonly IStatePropertyAccessor<UserProfile> _profileAccessor;
         public int PermissionLevel { get; set; } = 5;
+
         public CancelAndHelpDialog(string id, UserState userState)
             : base(id)
         {

--- a/Dialogs/CancelAndHelpDialog.cs
+++ b/Dialogs/CancelAndHelpDialog.cs
@@ -3,17 +3,23 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using CoreBot.Interfaces;
+using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Schema;
 
 namespace CoreBot.Dialogs
 {
-    public class CancelAndHelpDialog : ComponentDialog
+    public class CancelAndHelpDialog : ComponentDialog, IPermissionObject
     {
         protected const string whatElse = "What else can I do for you today?";
-        public CancelAndHelpDialog(string id)
+        private const string noPermission = "Sorry, you don't have privilege to use this functionality.";
+        protected readonly IStatePropertyAccessor<UserProfile> _profileAccessor;
+        public int PermissionLevel { get; set; } = 5;
+        public CancelAndHelpDialog(string id, UserState userState)
             : base(id)
         {
+            _profileAccessor = userState.CreateProperty<UserProfile>(nameof(UserProfile));
         }
 
         protected override async Task<DialogTurnResult> OnBeginDialogAsync(DialogContext innerDc, object options, CancellationToken cancellationToken = default(CancellationToken))
@@ -59,6 +65,25 @@ namespace CoreBot.Dialogs
             }
 
             return null;
+        }
+
+        protected async Task<DialogTurnResult> CheckPermissionStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        {
+            var userProfile = await _profileAccessor.GetAsync(stepContext.Context, () => new UserProfile());
+            if (HasPermission(userProfile.Permission))
+            {
+                return await stepContext.NextAsync(stepContext.Options, cancellationToken);
+            }
+            else
+            {
+                await stepContext.Context.SendActivityAsync(MessageFactory.Text(noPermission),cancellationToken);
+                return await stepContext.EndDialogAsync(null, cancellationToken);
+            }
+        }
+
+        public bool HasPermission(int permission)
+        {
+            return PermissionLevel >= permission;
         }
     }
 }

--- a/Dialogs/CancelAndHelpDialog.cs
+++ b/Dialogs/CancelAndHelpDialog.cs
@@ -3,7 +3,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using CoreBot.Interfaces;
+using CoreBot.Permission;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Schema;

--- a/Dialogs/CardDialog.cs
+++ b/Dialogs/CardDialog.cs
@@ -2,8 +2,6 @@
 using Microsoft.Bot.Builder.Dialogs;
 using Newtonsoft.Json.Linq;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/Dialogs/CardDialog.cs
+++ b/Dialogs/CardDialog.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CoreBot.Dialogs
+{
+    public class CardDialog : CancelAndHelpDialog
+    {
+        private readonly IStatePropertyAccessor<ConversationData> _conversationAccessor;
+        public CardDialog(string id, UserState userState, ConversationState conversationState) : base(id, userState)
+        {
+            _conversationAccessor = conversationState.CreateProperty<ConversationData>(nameof(ConversationData));
+        }
+
+        protected async Task<DialogTurnResult> DisableCardStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        {
+            var conversationData = await _conversationAccessor.GetAsync(stepContext.Context, () => new ConversationData());
+
+            var jobject = JObject.Parse((string)stepContext.Result);
+
+            var guid = (string)jobject["id"];
+
+            conversationData.DisabledCards.Add(guid, DateTime.Now);
+
+            return await stepContext.NextAsync(stepContext.Result, cancellationToken);
+        }
+    }
+}

--- a/Dialogs/ConfirmOrderDialog.cs
+++ b/Dialogs/ConfirmOrderDialog.cs
@@ -9,12 +9,13 @@ using System.Threading.Tasks;
 
 namespace CoreBot.Dialogs
 {
-    public class ConfirmOrderDialog : CancelAndHelpDialog
+    public class ConfirmOrderDialog : CardDialog
     {
         private const string noOrderMsg = "Sorry, you need to order something first.";
         private const string ignoreOrder = "Your order is still pending, you can confirm, cancel or add more products!";
 
-        public ConfirmOrderDialog(UserState userState) : base(nameof(ConfirmOrderDialog),userState)
+        public ConfirmOrderDialog(UserState userState, ConversationState conversationState) 
+            : base(nameof(ConfirmOrderDialog),userState, conversationState)
         {
             AddDialog(new TextPrompt(nameof(TextPrompt)));
             AddDialog(new ConfirmPrompt(nameof(ConfirmPrompt)));
@@ -23,6 +24,7 @@ namespace CoreBot.Dialogs
                 CheckPermissionStepAsync,
                 CheckOrderStepAsync,
                 ShowCardStepAsync,
+                DisableCardStepAsync,
                 ProcessValueStepAsync,
                 FinalStepAsync
             }));

--- a/Dialogs/ConfirmOrderDialog.cs
+++ b/Dialogs/ConfirmOrderDialog.cs
@@ -1,12 +1,9 @@
-﻿using AdaptiveCards;
-using CoreBot.Store;
+﻿using CoreBot.Utilities;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Schema;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -51,7 +48,7 @@ namespace CoreBot.Dialogs
         {
             var userProfile = await _profileAccessor.GetAsync(stepContext.Context, () => new UserProfile());
 
-            var attachment = CreateCardFromOrder(userProfile);
+            var attachment = CardUtils.CreateCardFromOrder(userProfile);
 
             var opts = new PromptOptions
             {
@@ -108,58 +105,6 @@ namespace CoreBot.Dialogs
             await stepContext.Context.SendActivityAsync(MessageFactory.Text(whatElse), cancellationToken);
 
             return await stepContext.EndDialogAsync(null, cancellationToken);
-        }
-
-        private Attachment CreateCardFromOrder(UserProfile userProfile)
-        {
-            string[] paths = { ".", "Cards", "confirmOrderCard.json" };
-            var cardJson = File.ReadAllText(Path.Combine(paths));
-            var card = AdaptiveCard.FromJson(cardJson).Card;
-
-            //Ara hem convertit el JSON a un AdaptiveCard i editarem els fragments que ens interessen.
-
-            //Primer editem el FactSet (informació de l'usuari que sortirà a la fitxa).
-            var containerFact = (card.Body[1] as AdaptiveContainer);
-            var factSet = (containerFact.Items[1] as AdaptiveFactSet);
-            factSet.Facts.Add(new AdaptiveFact("Ordered by:", userProfile.Name));
-            factSet.Facts.Add(new AdaptiveFact("Company:", userProfile.Company));
-
-            //Ara editarem la informació que sortirà dels productes
-            var containerProducts = (card.Body[3] as AdaptiveContainer);
-
-            userProfile.ProductCart.Products.RemoveAll(item => item == null);
-
-            foreach (SingleOrder order in userProfile.ProductCart.Products)
-            {
-                AdaptiveColumnSet columns = new AdaptiveColumnSet();
-                AdaptiveColumn productColumn = new AdaptiveColumn();
-
-                AdaptiveTextBlock product = new AdaptiveTextBlock(order.Product);
-                product.Wrap = true;
-
-                productColumn.Width = "stretch";
-                productColumn.Items.Add(product);
-                columns.Columns.Add(productColumn);
-
-                AdaptiveColumn amountColumn = new AdaptiveColumn();
-
-                AdaptiveTextBlock amount = new AdaptiveTextBlock(order.AmountToString());
-                amount.Wrap = true;
-
-                amountColumn.Width = "auto";
-                amountColumn.Items.Add(amount);
-                columns.Columns.Add(amountColumn);
-
-                containerProducts.Items.Add(columns);
-            }
-
-            var attachment = new Attachment()
-            {
-                Content = JsonConvert.DeserializeObject(JsonConvert.SerializeObject(card)),
-                ContentType = "application/vnd.microsoft.card.adaptive"
-            };
-
-            return attachment;
         }
     }
 }

--- a/Dialogs/MainDialog.cs
+++ b/Dialogs/MainDialog.cs
@@ -92,7 +92,10 @@ namespace CoreBot.Dialogs
                     var productInfo = luisResult.ToProductInfo(Configuration);
                     if (productInfo != null)
                     {
-                        var adaptiveCard = CreateCardFromProductInfo(stepContext.Context.Activity, productInfo);
+                        var attachment = CardUtils.CreateCardFromProductInfo(productInfo);
+                        var adaptiveCard = stepContext.Context.Activity.CreateReply();
+
+                        adaptiveCard.Attachments = new List<Attachment>() { attachment };
                         await stepContext.Context.SendActivityAsync(adaptiveCard, cancellationToken);
                     }
                     else
@@ -122,31 +125,6 @@ namespace CoreBot.Dialogs
             }
 
             return await stepContext.EndDialogAsync(null, cancellationToken);
-        }
-
-
-
-        // FUNCIONS AUXILIARS ALIENES A LA DEFINICIÓ DEL FLUX DE CONVERSA
-        private Activity CreateCardFromProductInfo(IActivity activity, ProductInfo productInfo)
-        {
-            var processedDisplayText = productInfo.DisplayText.Replace("\\n", System.Environment.NewLine);
-            var card = new AdaptiveCard("1.0");
-            if (productInfo.ImageURL != null)
-                card.Body.Add(new AdaptiveImage(url: productInfo.ImageURL));
-
-            card.Body.Add(new AdaptiveTextBlock() { Text = productInfo.Title, Weight = AdaptiveTextWeight.Bolder });
-            card.Body.Add(new AdaptiveTextBlock() { Text = processedDisplayText });
-            if (productInfo.StoreURL != null)
-                card.Actions.Add(new AdaptiveOpenUrlAction() { Title = "More information", Url = new System.Uri(productInfo.StoreURL) });
-            var resposta = new Attachment()
-            {
-                ContentType = AdaptiveCard.ContentType,
-                Content = card
-            };
-            var response = ((Activity)activity).CreateReply();
-
-            response.Attachments = new List<Attachment>() { resposta };
-            return response;
         }
     }
 }

--- a/Dialogs/MainDialog.cs
+++ b/Dialogs/MainDialog.cs
@@ -6,7 +6,6 @@ using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -16,12 +15,11 @@ namespace CoreBot.Dialogs
 {
     public class MainDialog : ComponentDialog
     {
-        protected readonly ILogger Logger;
         protected IBotServices BotServices;
         private readonly IStatePropertyAccessor<UserProfile> _profileAccessor;
         private readonly IConfiguration Configuration;
 
-        public MainDialog(ILogger<MainDialog> logger, IBotServices botServices, TechnicalAssistanceDialog technicalAssistance,
+        public MainDialog(IBotServices botServices, TechnicalAssistanceDialog technicalAssistance,
             OrderProductDialog orderProduct, AskUserInfoDialog infoDialog, UserState userState, ConfirmOrderDialog confirmOrderDialog,
             IConfiguration configuration)
             : base(nameof(MainDialog))

--- a/Dialogs/MainDialog.cs
+++ b/Dialogs/MainDialog.cs
@@ -47,7 +47,7 @@ namespace CoreBot.Dialogs
         {
             var userProfile = await _profileAccessor.GetAsync(stepContext.Context, () => new UserProfile());
 
-            if (!userProfile.askedForUserInfo)
+            if (!userProfile.AskedForUserInfo)
             {
                 return await stepContext.BeginDialogAsync(nameof(AskUserInfoDialog), cancellationToken);
             }
@@ -130,7 +130,7 @@ namespace CoreBot.Dialogs
         private Activity CreateCardFromProductInfo(IActivity activity, ProductInfo productInfo)
         {
             var processedDisplayText = productInfo.DisplayText.Replace("\\n", System.Environment.NewLine);
-            var card = new AdaptiveCard();
+            var card = new AdaptiveCard("1.0");
             if (productInfo.ImageURL != null)
                 card.Body.Add(new AdaptiveImage(url: productInfo.ImageURL));
 

--- a/Dialogs/MainDialog.cs
+++ b/Dialogs/MainDialog.cs
@@ -21,7 +21,7 @@ namespace CoreBot.Dialogs
 
         public MainDialog(IBotServices botServices, TechnicalAssistanceDialog technicalAssistance,
             OrderProductDialog orderProduct, AskUserInfoDialog infoDialog, UserState userState, ConfirmOrderDialog confirmOrderDialog,
-            IConfiguration configuration)
+            AddProductInfoDialog addProductInfoDialog, IConfiguration configuration)
             : base(nameof(MainDialog))
         {
             AddDialog(new TextPrompt(nameof(TextPrompt)));
@@ -29,6 +29,7 @@ namespace CoreBot.Dialogs
             AddDialog(technicalAssistance);
             AddDialog(infoDialog);
             AddDialog(confirmOrderDialog);
+            AddDialog(addProductInfoDialog);
             AddDialog(new WaterfallDialog(nameof(WaterfallDialog), new WaterfallStep[]
             {
                 WelcomeStepAsync,
@@ -117,6 +118,9 @@ namespace CoreBot.Dialogs
 
                 case "ConfirmCart":
                     return await stepContext.BeginDialogAsync(nameof(ConfirmOrderDialog), cancellationToken);
+
+                case "AddProductInfo":
+                    return await stepContext.BeginDialogAsync(nameof(AddProductInfoDialog), cancellationToken);
 
                 case "QnA":
                     var answer = (string)stepContext.Result;

--- a/Dialogs/OrderProductDialog.cs
+++ b/Dialogs/OrderProductDialog.cs
@@ -30,6 +30,7 @@ namespace CoreBot.Dialogs
                }));
 
             InitialDialogId = nameof(WaterfallDialog);
+            PermissionLevel = 3;
         }
 
         private async Task<DialogTurnResult> ProductStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)

--- a/Dialogs/TechnicalAssistanceDialog.cs
+++ b/Dialogs/TechnicalAssistanceDialog.cs
@@ -16,8 +16,8 @@ namespace CoreBot.Dialogs
 
         private IStatePropertyAccessor<ConversationData> _conversationDataAccessor;
 
-        public TechnicalAssistanceDialog(ConversationState conversationState)
-            : base(nameof(TechnicalAssistanceDialog))
+        public TechnicalAssistanceDialog(ConversationState conversationState, UserState userState)
+            : base(nameof(TechnicalAssistanceDialog),userState)
         {
             //_conversationDataAccessor = conversationState.CreateProperty<ConversationData>(nameof(ConversationData));
 

--- a/Extensions/RecognizerResultExtensions.cs
+++ b/Extensions/RecognizerResultExtensions.cs
@@ -77,6 +77,7 @@ namespace CoreBot.Extensions
                 // Tanquem el reader i la connexió abans de sortir.
                 reader.Close();
                 connection.Close();
+                connection.Dispose();
             }
 
             return null;

--- a/Permission/IPermissionObject.cs
+++ b/Permission/IPermissionObject.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace CoreBot.Interfaces
+{
+    interface IPermissionObject
+    {
+        int PermissionLevel { get; set; }
+
+        bool HasPermission(int permission);
+    }
+}

--- a/Permission/IPermissionObject.cs
+++ b/Permission/IPermissionObject.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace CoreBot.Interfaces
+namespace CoreBot.Permission
 {
     interface IPermissionObject
     {

--- a/Startup.cs
+++ b/Startup.cs
@@ -54,6 +54,8 @@ namespace Microsoft.BotBuilderSamples
 
             services.AddSingleton<ConfirmOrderDialog>();
 
+            services.AddSingleton<AddProductInfoDialog>();
+
             // The Dialog that will be run by the bot.
             services.AddSingleton<MainDialog>();
 

--- a/Store/ProductCart.cs
+++ b/Store/ProductCart.cs
@@ -1,17 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace CoreBot.Store
 {
     public class ProductCart
     {
-        public List<SingleOrder> Products { get; } = new List<SingleOrder>();
+        public List<SingleOrder> Products { get; }
 
         public ProductCart(SingleOrder singleOrder)
         {
-            Products.Add(singleOrder);
+            Products = new List<SingleOrder>
+            {
+                singleOrder
+            };
         }
 
         public void AddOrder(SingleOrder singleOrder)

--- a/UserProfile.cs
+++ b/UserProfile.cs
@@ -8,10 +8,12 @@ namespace CoreBot
 {
     public class UserProfile
     {
-        public string name { get; set; }
-        public string username { get; set; }
-        public ProductCart productCart { get; set; }
-        public bool askedForUserInfo { get; set; } = false;
-        public string company { get; set; }
+        public string Name { get; set; }
+        public string Username { get; set; }
+        public ProductCart ProductCart { get; set; }
+        public bool AskedForUserInfo { get; set; } = false;
+        public string Company { get; set; }
+
+        public int Permission { get; set; } = 5;
     }
 }

--- a/Utilities/CardUtils.cs
+++ b/Utilities/CardUtils.cs
@@ -4,6 +4,7 @@ using Microsoft.Bot.Schema;
 using Newtonsoft.Json;
 using System;
 using System.IO;
+using System.Text.RegularExpressions;
 
 namespace CoreBot.Utilities
 {
@@ -32,7 +33,8 @@ namespace CoreBot.Utilities
         {
             string[] paths = { ".", "Cards", "confirmOrderCard.json" };
             var cardJson = File.ReadAllText(Path.Combine(paths));
-            var card = AdaptiveCard.FromJson(cardJson).Card;
+            var processedJson = AddGuidToJson(cardJson);
+            var card = AdaptiveCard.FromJson(processedJson).Card;
 
             //Ara hem convertit el JSON a un AdaptiveCard i editarem els fragments que ens interessen.
 
@@ -78,6 +80,16 @@ namespace CoreBot.Utilities
             };
 
             return attachment;
+        }
+
+        static public string AddGuidToJson(string json)
+        {
+            string regex = @"submitButton[0-9]";
+            Regex r = new Regex(regex);
+            Guid g = Guid.NewGuid();
+            var replaced = r.Replace(json, g.ToString());
+
+            return replaced;
         }
     }
 }

--- a/Utilities/CardUtils.cs
+++ b/Utilities/CardUtils.cs
@@ -10,6 +10,7 @@ namespace CoreBot.Utilities
 {
     public static class CardUtils
     {
+        public const string sameCardMsg = "Don't use the same Submit Card twice. If you want to submit new data ask for the Card again.";
         public static Attachment CreateCardFromProductInfo(ProductInfo productInfo)
         {
             var processedDisplayText = productInfo.DisplayText.Replace("\\n", Environment.NewLine);

--- a/Utilities/CardUtils.cs
+++ b/Utilities/CardUtils.cs
@@ -1,0 +1,83 @@
+﻿using AdaptiveCards;
+using CoreBot.Store;
+using Microsoft.Bot.Schema;
+using Newtonsoft.Json;
+using System;
+using System.IO;
+
+namespace CoreBot.Utilities
+{
+    public static class CardUtils
+    {
+        public static Attachment CreateCardFromProductInfo(ProductInfo productInfo)
+        {
+            var processedDisplayText = productInfo.DisplayText.Replace("\\n", Environment.NewLine);
+            var card = new AdaptiveCard("1.0");
+            if (productInfo.ImageURL != null)
+                card.Body.Add(new AdaptiveImage(url: productInfo.ImageURL));
+
+            card.Body.Add(new AdaptiveTextBlock() { Text = productInfo.Title, Weight = AdaptiveTextWeight.Bolder });
+            card.Body.Add(new AdaptiveTextBlock() { Text = processedDisplayText });
+            if (productInfo.StoreURL != null)
+                card.Actions.Add(new AdaptiveOpenUrlAction() { Title = "More information", Url = new Uri(productInfo.StoreURL) });
+            var resposta = new Attachment()
+            {
+                ContentType = AdaptiveCard.ContentType,
+                Content = card
+            };
+            return resposta;
+        }
+
+        public static Attachment CreateCardFromOrder(UserProfile userProfile)
+        {
+            string[] paths = { ".", "Cards", "confirmOrderCard.json" };
+            var cardJson = File.ReadAllText(Path.Combine(paths));
+            var card = AdaptiveCard.FromJson(cardJson).Card;
+
+            //Ara hem convertit el JSON a un AdaptiveCard i editarem els fragments que ens interessen.
+
+            //Primer editem el FactSet (informació de l'usuari que sortirà a la fitxa).
+            var containerFact = (card.Body[1] as AdaptiveContainer);
+            var factSet = (containerFact.Items[1] as AdaptiveFactSet);
+            factSet.Facts.Add(new AdaptiveFact("Ordered by:", userProfile.Name));
+            factSet.Facts.Add(new AdaptiveFact("Company:", userProfile.Company));
+
+            //Ara editarem la informació que sortirà dels productes
+            var containerProducts = (card.Body[3] as AdaptiveContainer);
+
+            userProfile.ProductCart.Products.RemoveAll(item => item == null);
+
+            foreach (SingleOrder order in userProfile.ProductCart.Products)
+            {
+                AdaptiveColumnSet columns = new AdaptiveColumnSet();
+                AdaptiveColumn productColumn = new AdaptiveColumn();
+
+                AdaptiveTextBlock product = new AdaptiveTextBlock(order.Product);
+                product.Wrap = true;
+
+                productColumn.Width = "stretch";
+                productColumn.Items.Add(product);
+                columns.Columns.Add(productColumn);
+
+                AdaptiveColumn amountColumn = new AdaptiveColumn();
+
+                AdaptiveTextBlock amount = new AdaptiveTextBlock(order.AmountToString());
+                amount.Wrap = true;
+
+                amountColumn.Width = "auto";
+                amountColumn.Items.Add(amount);
+                columns.Columns.Add(amountColumn);
+
+                containerProducts.Items.Add(columns);
+            }
+
+            var attachment = new Attachment()
+            {
+                Content = JsonConvert.DeserializeObject(JsonConvert.SerializeObject(card)),
+                ContentType = "application/vnd.microsoft.card.adaptive"
+            };
+
+            return attachment;
+        }
+    }
+}


### PR DESCRIPTION
While implementing the _AddProduct_ Dialog QoL decisions have also been implemented:

**[Feature] Implemented permission system**
One of the main features that needed to be implemented in Greta. The more privilege a user has, the more features it has access to.
- Users now have a permission level (0-5) 0 being the highest (superuser) and 5 being the lowest (unregistered).
- Actions and Dialogs (classes that implement the `IPermission` interface) now require a certain level of permission to be executed.
- Added a `CheckPermission` waterfall step at every dialog that implements the `IPermission` interface.

**[Feature] Implemented Card validation**
One of the main problems I had while using Cards is that users can interact with cards when it was not expected. (Ex: using a card sent in a previous dialog in another dialog context).
- When a card is created I assign a [GUID](https://docs.microsoft.com/en-us/windows/win32/api/guiddef/ns-guiddef-guid) to all the submit buttons.
- Added a `DisableCard` waterfall step at every dialog that extends the `CardDialog` class so the GUID is registered in the `ConversationState` upon use.
- Cards with same GUID can't be used twice.

**[Dialog] VITROSEP users and Superusers can now interact with the Products stored in the DB**
Adding products to the AzureDB using SQLServer can be a tedious task for someone who is not familiar with SQL.
- Added a dialog where products can be added to the DB through Greta.
- The user can also check which products they have added.

**[Code Structure] Moved card functions to static class CardUtils**
Having Card related functions inside Dialogs looked like a bad practice. The new class `CardUtils` now contains static methods that are used to create, modify and interact with cards without having to add the logic at every dialog.