### PR TITLE
User validation

### DIFF
--- a/CoreBot.csproj
+++ b/CoreBot.csproj
@@ -21,6 +21,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.2.9" />
     <PackageReference Include="Refit" Version="4.7.9" />

--- a/Dialogs/AddProductInfoDialog.cs
+++ b/Dialogs/AddProductInfoDialog.cs
@@ -42,10 +42,7 @@ namespace CoreBot.Dialogs
 
         private async Task<DialogTurnResult> PromptCardStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
-            string[] paths = { ".", "Cards", "productInfoFillingCard.json" };
-            var cardJson = File.ReadAllText(Path.Combine(paths));
-            var processedJson = CardUtils.AddGuidToJson(cardJson);
-            var card = AdaptiveCard.FromJson(processedJson).Card;
+            var card = CardUtils.CreateCardFromJson("productInfoFillingCard");
 
             var activity = new Activity
             {

--- a/Dialogs/CancelAndHelpDialog.cs
+++ b/Dialogs/CancelAndHelpDialog.cs
@@ -19,6 +19,7 @@ namespace CoreBot.Dialogs
         protected const int REPRESENTATIVE = 3;
         protected const int LEAD = 4;
         protected const int UNREGISTERED = 5;
+        protected static readonly string[] permissions = { "Superuser", "Vitrosep", "Customer", "Representative", "Lead", "Unregistered"};
 
         protected const string whatElse = "What else can I do for you today?";
         private const string noPermission = "Sorry, you don't have privilege to use this functionality.";
@@ -87,6 +88,20 @@ namespace CoreBot.Dialogs
             {
                 await stepContext.Context.SendActivityAsync(MessageFactory.Text(noPermission),cancellationToken);
                 return await stepContext.EndDialogAsync(null, cancellationToken);
+            }
+        }
+
+        protected int ResolvePermission(string permission)
+        {
+            switch (permission)
+            {
+                case "Superuser": return SUPERUSER;
+                case "Vitrosep": return VITROSEP;
+                case "Customer": return CUSTOMERS;
+                case "Representative": return REPRESENTATIVE;
+                case "Lead": return LEAD;
+                case "Unregistered": return UNREGISTERED;
+                default: return -1;
             }
         }
 

--- a/Dialogs/CardDialog.cs
+++ b/Dialogs/CardDialog.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Bot.Builder;
+﻿using CoreBot.Utilities;
+using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Newtonsoft.Json.Linq;
 using System;
@@ -19,11 +20,12 @@ namespace CoreBot.Dialogs
         {
             var conversationData = await _conversationAccessor.GetAsync(stepContext.Context, () => new ConversationData());
 
-            var jobject = JObject.Parse((string)stepContext.Result);
-
-            var guid = (string)jobject["id"];
-
-            conversationData.DisabledCards.Add(guid, DateTime.Now);
+            var result = (string)stepContext.Result;
+            if (result.StartsWith('{'))
+            {
+                var guid = CardUtils.GetGuidFromResult(result);
+                conversationData.DisabledCards.Add(guid, DateTime.Now);
+            }
 
             return await stepContext.NextAsync(stepContext.Result, cancellationToken);
         }

--- a/Dialogs/MainDialog.cs
+++ b/Dialogs/MainDialog.cs
@@ -23,7 +23,7 @@ namespace CoreBot.Dialogs
 
         public MainDialog(IBotServices botServices, TechnicalAssistanceDialog technicalAssistance,
             OrderProductDialog orderProduct, AskUserInfoDialog infoDialog, UserState userState, ConfirmOrderDialog confirmOrderDialog,
-            AddProductInfoDialog addProductInfoDialog, IConfiguration configuration)
+            AddProductInfoDialog addProductInfoDialog, UserValidationDialog userValidationDialog, IConfiguration configuration)
             : base(nameof(MainDialog))
         {
             AddDialog(new TextPrompt(nameof(TextPrompt)));
@@ -32,6 +32,7 @@ namespace CoreBot.Dialogs
             AddDialog(infoDialog);
             AddDialog(confirmOrderDialog);
             AddDialog(addProductInfoDialog);
+            AddDialog(userValidationDialog);
             AddDialog(new WaterfallDialog(nameof(WaterfallDialog), new WaterfallStep[]
             {
                 WelcomeStepAsync,
@@ -128,6 +129,9 @@ namespace CoreBot.Dialogs
                     string products = await GetProductNamesAsync(stepContext.Context);
                     await stepContext.Context.SendActivityAsync(MessageFactory.Text(products), cancellationToken);
                     break;
+
+                case "ValidateUser":
+                    return await stepContext.BeginDialogAsync(nameof(UserValidationDialog), null, cancellationToken);
 
                 case "QnA":
                     var answer = (string)stepContext.Result;

--- a/Dialogs/TechnicalAssistanceDialog.cs
+++ b/Dialogs/TechnicalAssistanceDialog.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Bot.Builder;
+﻿using CoreBot.Extensions;
+using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Dialogs.Choices;
 using Microsoft.Bot.Schema;
@@ -65,7 +66,7 @@ namespace CoreBot.Dialogs
 
         private async Task<DialogTurnResult> OptionalStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
-            var nodeActual = (NodeDecisio)stepContext.Values["Node"];
+            var nodeActual = stepContext.GetValue<NodeDecisio>("Node");
             if(nodeActual.fills.Count == 0)
             {
                 var result = (bool)stepContext.Result;

--- a/Dialogs/UserValidationDialog.cs
+++ b/Dialogs/UserValidationDialog.cs
@@ -1,0 +1,146 @@
+﻿using CoreBot.Extensions;
+using CoreBot.Models;
+using CoreBot.Store;
+using CoreBot.Utilities;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Builder.Dialogs.Choices;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CoreBot.Dialogs
+{
+    public class UserValidationDialog : CardDialog
+    {
+        private const string askCustNameMsg = "Enter the name (and first name) of the new customer you want to validate.";
+        private const string carouselMsg = "Which one of these customers do you want to validate?";
+        private const string permissionMsg = "Which level of permission do you want the user to have? (sorted from highest to lowest)";
+        private readonly IPrestashopApi PrestashopApi;
+        private readonly IServiceProvider ServiceProvider;
+
+        public UserValidationDialog(UserState userState, ConversationState conversationState, IPrestashopApi prestashopApi,
+            IServiceProvider serviceProvider) : 
+            base(nameof(UserValidationDialog), userState, conversationState)
+        {
+            AddDialog(new TextPrompt(nameof(TextPrompt)));
+            AddDialog(new TextPrompt("CustomerValidationPrompt",ValidateCustomerInputAsync));
+            AddDialog(new ChoicePrompt(nameof(ChoicePrompt)));
+            AddDialog(new WaterfallDialog(nameof(WaterfallDialog), new WaterfallStep[]
+            {
+                CheckPermissionStepAsync,
+                CustomerNameStepAsync,
+                DisplayChoiceStepAsync,
+                DisableCardStepAsync,
+                SetPermissionStepAsync,
+                ValidateUserStepAsync
+            }));
+
+            ServiceProvider = serviceProvider;
+            PrestashopApi = prestashopApi;
+            PermissionLevel = SUPERUSER;
+            InitialDialogId = nameof(WaterfallDialog);
+        }
+
+        private async Task<DialogTurnResult> CustomerNameStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        {
+            var opts = new PromptOptions
+            {
+                Prompt = MessageFactory.Text(askCustNameMsg)
+            };
+            return await stepContext.PromptAsync("CustomerValidationPrompt", opts, cancellationToken);
+        }
+
+        private async Task<DialogTurnResult> DisplayChoiceStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        {
+            var name = ((string)stepContext.Result).Split(null);
+
+            var customers = name.Length == 1 
+                ? (await PrestashopApi.GetCustomerByFirstName(name[0]))
+                : (await PrestashopApi.GetCustomerByFullName(name[0], name[1]));
+
+            if (customers.Customers.Length == 1)
+            {
+                return await stepContext.NextAsync(customers.First().Id, cancellationToken);
+            } 
+            else
+            {
+                var activity = MessageFactory.Carousel(customers.ToSelectionCarousel(), carouselMsg);
+                await stepContext.Context.SendActivityAsync(activity,cancellationToken);
+                return await stepContext.PromptAsync(nameof(TextPrompt), new PromptOptions { Prompt = MessageFactory.Text("") });
+            }
+        }
+
+        private async Task<DialogTurnResult> SetPermissionStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        {
+            stepContext.Values["id"] = stepContext.Result.GetType() == typeof(int) 
+                ? (int)stepContext.Result 
+                : CardUtils.GetValueFromAction<int>((string)stepContext.Result);
+
+            var promptOptions = new PromptOptions
+            {
+                Prompt = MessageFactory.Text(permissionMsg),
+                RetryPrompt = MessageFactory.Text("Choose a value from the list below (sorted from highest to lowest)"),
+                Choices = ChoiceFactory.ToChoices(permissions)
+            };
+
+            return await stepContext.PromptAsync(nameof(ChoicePrompt), promptOptions, cancellationToken);
+        }
+
+        private async Task<DialogTurnResult> ValidateUserStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        {
+            var choice = (FoundChoice)stepContext.Result;
+
+            var profile = new Models.UserProfile()
+            {
+                Permission  = choice.Index,
+                PrestashopId = stepContext.GetValue<int>("id")
+            };
+
+            AddUserProfile(profile);
+
+            await stepContext.Context.SendActivityAsync(MessageFactory.Text(
+                "A new user has been added. He can now login and start using Greta!"),cancellationToken);
+            return await stepContext.EndDialogAsync(null, cancellationToken);
+        }
+
+        private async Task<bool> ValidateCustomerInputAsync(PromptValidatorContext<string> promptContext, CancellationToken cancellationToken)
+        {
+            string[] words = promptContext.Context.Activity.Text.Split(null);
+            bool result = false;
+
+            if (words.Length == 2)
+            {
+                var collection = await PrestashopApi.GetCustomerByFullName(words[0],words[1]);
+
+                result = collection.Customers.Length > 0;
+            }
+            else if (words.Length == 1)
+            {
+                var collection = await PrestashopApi.GetCustomerByFirstName(words[0]);
+
+                result = collection.Customers.Length > 0;
+            }
+
+            if (!result)
+            {
+                var response = $"There's no customer named {promptContext.Context.Activity.Text} in PrestaShop. Please, try again or cancel.";
+                await promptContext.Context.SendActivityAsync(response);
+            }
+
+            return await Task.FromResult(result);
+        }
+
+        private void AddUserProfile(Models.UserProfile userProfile)
+        {
+            using (var scope = this.ServiceProvider.CreateScope())
+            {
+                var scopedService = scope.ServiceProvider.GetRequiredService<GretaDBContext>();
+
+                scopedService.Add(userProfile);
+                scopedService.SaveChanges();
+            }
+        }
+    }
+}

--- a/Extensions/StepContextExtensions.cs
+++ b/Extensions/StepContextExtensions.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.Bot.Builder.Dialogs;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace CoreBot.Extensions
+{
+    public static class StepContextExtensions
+    {
+        public static T GetValue<T>(this WaterfallStepContext stepContext, string index)
+        {
+            if (stepContext.Values.TryGetValue(index, out object value))
+                return (T)value;
+
+            else throw new KeyNotFoundException();
+        }
+    }
+}

--- a/Models/GretaDBContext.cs
+++ b/Models/GretaDBContext.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace CoreBot.Models
+{
+    public partial class GretaDBContext : DbContext
+    {
+        public GretaDBContext()
+        {
+        }
+
+        public GretaDBContext(DbContextOptions<GretaDBContext> options)
+            : base(options)
+        {
+        }
+
+        public virtual DbSet<Naquestions> Naquestions { get; set; }
+        public virtual DbSet<OrderLine> OrderLine { get; set; }
+        public virtual DbSet<UserProfile> UserProfile { get; set; }
+
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Naquestions>(entity =>
+            {
+                entity.HasKey(e => e.QuestionId);
+
+                entity.ToTable("NAQuestions");
+
+                entity.Property(e => e.QuestionText)
+                    .IsRequired()
+                    .HasMaxLength(512)
+                    .IsUnicode(false);
+
+                entity.HasOne(d => d.User)
+                    .WithMany(p => p.Naquestions)
+                    .HasForeignKey(d => d.UserId)
+                    .OnDelete(DeleteBehavior.ClientSetNull)
+                    .HasConstraintName("FK_NAQuestions_UserProfile");
+            });
+
+            modelBuilder.Entity<OrderLine>(entity =>
+            {
+                entity.HasOne(d => d.User)
+                    .WithMany(p => p.OrderLine)
+                    .HasForeignKey(d => d.UserId)
+                    .OnDelete(DeleteBehavior.ClientSetNull)
+                    .HasConstraintName("FK_OrderLine_UserProfile");
+            });
+
+            modelBuilder.Entity<UserProfile>(entity =>
+            {
+                entity.HasKey(e => e.Id);
+
+                entity.Property(e => e.CreationDate)
+                    .HasColumnType("date")
+                    .HasDefaultValueSql("(getdate())");
+
+                entity.Property(e => e.Permission).HasDefaultValueSql("((5))");
+
+                entity.Property(e => e.PrestashopId).HasColumnName("Prestashop_Id");
+
+                entity.Property(e => e.Id).ValueGeneratedOnAdd();
+            });
+        }
+    }
+}

--- a/Models/Naquestions.cs
+++ b/Models/Naquestions.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace CoreBot.Models
+{
+    public partial class Naquestions
+    {
+        public int QuestionId { get; set; }
+        public string QuestionText { get; set; }
+        public int UserId { get; set; }
+
+        public UserProfile User { get; set; }
+    }
+}

--- a/Models/OrderLine.cs
+++ b/Models/OrderLine.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace CoreBot.Models
+{
+    public partial class OrderLine
+    {
+        public int Id { get; set; }
+        public int Product { get; set; }
+        public int Amount { get; set; }
+        public int UserId { get; set; }
+
+        public UserProfile User { get; set; }
+    }
+}

--- a/Models/UserProfile.cs
+++ b/Models/UserProfile.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace CoreBot.Models
+{
+    public partial class UserProfile
+    {
+        public UserProfile()
+        {
+            Naquestions = new HashSet<Naquestions>();
+            OrderLine = new HashSet<OrderLine>();
+        }
+
+        public UserProfile(int permission)
+        {
+            Permission = permission;
+            Naquestions = new HashSet<Naquestions>();
+            OrderLine = new HashSet<OrderLine>();
+        }
+
+        public int Id { get; set; }
+        public int? PrestashopId { get; set; }
+        public bool Welcomed { get; set; }
+        public int Permission { get; set; }
+        public DateTime CreationDate { get; set; }
+
+        public ICollection<Naquestions> Naquestions { get; set; }
+        public ICollection<OrderLine> OrderLine { get; set; }
+    }
+}

--- a/Startup.cs
+++ b/Startup.cs
@@ -15,6 +15,8 @@ using Refit;
 using CoreBot.Store;
 using System;
 using System.Net.Http.Headers;
+using Microsoft.EntityFrameworkCore;
+using CoreBot.Models;
 
 namespace Microsoft.BotBuilderSamples
 {
@@ -49,7 +51,6 @@ namespace Microsoft.BotBuilderSamples
             // Creem un ConversationState que ens ajudarà amb els nodes de conversa del TechSupport.
             services.AddSingleton<ConversationState>();
 
-            // Afegim el diàleg de suport tècnic
             services.AddSingleton<TechnicalAssistanceDialog>();
 
             services.AddSingleton<AskUserInfoDialog>();
@@ -59,6 +60,8 @@ namespace Microsoft.BotBuilderSamples
             services.AddSingleton<ConfirmOrderDialog>();
 
             services.AddSingleton<AddProductInfoDialog>();
+
+            services.AddSingleton<UserValidationDialog>();
 
             // The Dialog that will be run by the bot.
             services.AddSingleton<MainDialog>();
@@ -79,7 +82,9 @@ namespace Microsoft.BotBuilderSamples
                 })
                 .ConfigureHttpClient((c) => c.BaseAddress = new Uri(storeUrl))
                 .ConfigureHttpClient((c) => c.DefaultRequestHeaders.Add("Authorization", "Basic " + encoded));
-                
+
+            services.AddDbContext<GretaDBContext>(options =>
+                options.UseSqlServer(Configuration.GetConnectionString("DefaultConnection")));
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/Store/Carouselable.cs
+++ b/Store/Carouselable.cs
@@ -1,0 +1,56 @@
+﻿using AdaptiveCards;
+using CoreBot.Store.Entity;
+using Microsoft.Bot.Schema;
+using System;
+using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace CoreBot.Store
+{
+    public class Carouselable<T> where T : IAttachable
+    {
+        [XmlIgnore]
+        public T[] Elements { get; set; }
+
+        public Attachment[] ToCarousel()
+        {
+            int i = 0;
+            List<Attachment> attachments = new List<Attachment>();
+
+            while (i < Elements.Length)
+            {
+                attachments.Add(Elements[i].ToAttachment());
+                i++;
+            }
+
+            return attachments.ToArray();
+        }
+
+        public Attachment[] ToSelectionCarousel()
+        {
+            int i = 0;
+            List<Attachment> attachments = new List<Attachment>();
+            Guid guid = Guid.NewGuid();
+
+            while (i < Elements.Length)
+            {
+                var card = Elements[i].ToAdaptiveCard();
+                card.Actions.Add(new AdaptiveSubmitAction
+                {
+                    Title = "SELECT",
+                    DataJson = $@"{{ ""id"" : ""{guid.ToString()}"", ""action"" : ""{i}""}}"
+                });
+
+                var attachment = new Attachment
+                {
+                    Content = card,
+                    ContentType = "application/vnd.microsoft.card.adaptive"
+                };
+
+                attachments.Add(attachment);
+            }
+
+            return attachments.ToArray();
+        }
+    }
+}

--- a/Store/Entity/Customer.cs
+++ b/Store/Entity/Customer.cs
@@ -7,7 +7,7 @@ namespace CoreBot.Store.Entity
     public class Customer : IAttachable
     {
         [XmlElement("id")]
-        public int Id { get; set; }
+        public override int Id { get; set; }
 
         [XmlElement("passwd")]
         public string Password { get; set; }
@@ -30,21 +30,21 @@ namespace CoreBot.Store.Entity
         [XmlElement("date_upd")]
         public string UpdateDateString
         {
-            get { return this.UpdateDate.ToString("yyyy-MM-dd HH:mm:ss"); }
-            set { this.UpdateDate = DateTime.Parse(value); }
+            get { return UpdateDate.ToString("yyyy-MM-dd HH:mm:ss"); }
+            set { UpdateDate = DateTime.Parse(value); }
         }
 
         public override AdaptiveCard ToAdaptiveCard()
         {
             var card = new AdaptiveCard("1.0");
-            card.Body.Add(new AdaptiveTextBlock
+            card.Body.Add(new AdaptiveTextBlock()
             {
-                Text = FirstName + LastName,
+                Text = FirstName + " " + LastName,
                 Weight = AdaptiveTextWeight.Bolder
             });
-            card.Body.Add(new AdaptiveTextBlock
+            card.Body.Add(new AdaptiveTextBlock()
             {
-                Text = $"Company: {Company}\n Email: {Email}"
+                Text = $"Company: {Company}\n\n Email: {Email}"
             });
 
             return card;
@@ -60,11 +60,6 @@ namespace CoreBot.Store.Entity
         {
             get { return Elements; }
             set { Elements = value; }
-        }
-
-        public Customer First()
-        {
-            return Customers.Length > 0 ? Customers[0] : null;
         }
     }
 }

--- a/Store/Entity/Customer.cs
+++ b/Store/Entity/Customer.cs
@@ -1,9 +1,10 @@
-﻿using System;
+﻿using AdaptiveCards;
+using System;
 using System.Xml.Serialization;
 
 namespace CoreBot.Store.Entity
 {
-    public class Customer
+    public class Customer : IAttachable
     {
         [XmlElement("id")]
         public int Id { get; set; }
@@ -32,14 +33,34 @@ namespace CoreBot.Store.Entity
             get { return this.UpdateDate.ToString("yyyy-MM-dd HH:mm:ss"); }
             set { this.UpdateDate = DateTime.Parse(value); }
         }
+
+        public override AdaptiveCard ToAdaptiveCard()
+        {
+            var card = new AdaptiveCard("1.0");
+            card.Body.Add(new AdaptiveTextBlock
+            {
+                Text = FirstName + LastName,
+                Weight = AdaptiveTextWeight.Bolder
+            });
+            card.Body.Add(new AdaptiveTextBlock
+            {
+                Text = $"Company: {Company}\n Email: {Email}"
+            });
+
+            return card;
+        }
     }
 
     [XmlRoot("prestashop")]
-    public class CustomerCollection
+    public class CustomerCollection : Carouselable<Customer>
     {
         [XmlArray("customers")]
         [XmlArrayItem("customer", typeof(Customer))]
-        public Customer[] Customers { get; set; }
+        public Customer[] Customers 
+        {
+            get { return Elements; }
+            set { Elements = value; }
+        }
 
         public Customer First()
         {

--- a/Store/Entity/Product.cs
+++ b/Store/Entity/Product.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿using AdaptiveCards;
+using CoreBot.Utilities;
+using Microsoft.Bot.Schema;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -6,7 +9,7 @@ using System.Xml.Serialization;
 
 namespace CoreBot.Store.Entity
 {
-    public class Product
+    public class Product : IAttachable
     {
         [XmlElement("id")]
         public int Id { get; set; }
@@ -41,6 +44,23 @@ namespace CoreBot.Store.Entity
 
             return "";
         }
+
+        public override AdaptiveCard ToAdaptiveCard()
+        {
+            var card = new AdaptiveCard("1.0");
+            card.Body.Add(new AdaptiveImage
+            {
+                Url = new Uri(Image.Url)
+            });
+            card.Body.Add(new AdaptiveTextBlock
+            {
+                Text = GetNameByLanguage(CardUtils.ENGLISH),
+                Weight = AdaptiveTextWeight.Bolder
+            });
+            card.Body.Add(new AdaptiveTextBlock(GetDescriptionByLanguage(CardUtils.ENGLISH)));
+
+            return card;
+        }
     }
 
     public class Language
@@ -68,10 +88,14 @@ namespace CoreBot.Store.Entity
     }
 
     [XmlRoot("prestashop")]
-    public class ProductCollection
+    public class ProductCollection : Carouselable<Product>
     {
         [XmlArray("products")]
         [XmlArrayItem("product", typeof(Product))]
-        public Product[] Products { get; set; }
+        public Product[] Products 
+        {
+            get { return Elements; }
+            set { Elements = value; }
+        }
     }
 }

--- a/Store/Entity/Product.cs
+++ b/Store/Entity/Product.cs
@@ -2,20 +2,17 @@
 using CoreBot.Utilities;
 using Microsoft.Bot.Schema;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using System.Xml.Serialization;
 
 namespace CoreBot.Store.Entity
 {
-    public class Product : IAttachable
+    public class Product : IImageAttachable
     {
         [XmlElement("id")]
-        public int Id { get; set; }
+        public override int Id { get; set; }
 
         [XmlElement("id_default_image")]
-        public Image Image { get; set; }
+        public override Image Image { get; set; }
 
         [XmlArray("name")]
         [XmlArrayItem("language", typeof(Language))]
@@ -48,11 +45,7 @@ namespace CoreBot.Store.Entity
         public override AdaptiveCard ToAdaptiveCard()
         {
             var card = new AdaptiveCard("1.0");
-            card.Body.Add(new AdaptiveImage
-            {
-                Url = new Uri(Image.Url)
-            });
-            card.Body.Add(new AdaptiveTextBlock
+            card.Body.Add(new AdaptiveTextBlock()
             {
                 Text = GetNameByLanguage(CardUtils.ENGLISH),
                 Weight = AdaptiveTextWeight.Bolder
@@ -88,7 +81,7 @@ namespace CoreBot.Store.Entity
     }
 
     [XmlRoot("prestashop")]
-    public class ProductCollection : Carouselable<Product>
+    public class ProductCollection : ImageCarouselable<Product>
     {
         [XmlArray("products")]
         [XmlArrayItem("product", typeof(Product))]

--- a/Store/IAttachable.cs
+++ b/Store/IAttachable.cs
@@ -5,11 +5,17 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Xml.Serialization;
 
 namespace CoreBot.Store.Entity
 {
+    /// <summary>
+    /// Represents an object that can be rendered as an Adaptive attachment.
+    /// </summary>
     public abstract class IAttachable
     {
+        [XmlIgnore]
+        public abstract int Id { get; set; }
         public Attachment ToAttachment()
         {
             return CardUtils.AdaptiveCardToAttachment(ToAdaptiveCard());

--- a/Store/IAttachable.cs
+++ b/Store/IAttachable.cs
@@ -1,0 +1,20 @@
+﻿using AdaptiveCards;
+using CoreBot.Utilities;
+using Microsoft.Bot.Schema;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace CoreBot.Store.Entity
+{
+    public abstract class IAttachable
+    {
+        public Attachment ToAttachment()
+        {
+            return CardUtils.AdaptiveCardToAttachment(ToAdaptiveCard());
+        }
+
+        public abstract AdaptiveCard ToAdaptiveCard();
+    }
+}

--- a/Store/IImageAttachable.cs
+++ b/Store/IImageAttachable.cs
@@ -1,0 +1,31 @@
+﻿using AdaptiveCards;
+using CoreBot.Store.Entity;
+using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+
+namespace CoreBot.Store
+{
+    public abstract class IImageAttachable : IAttachable
+    {
+        [XmlIgnore]
+        public abstract Image Image { get; set; }
+
+        public AdaptiveCard ToImageAdaptiveCard(IConfiguration configuration)
+        {
+            var card = ToAdaptiveCard();
+            var apiKey = configuration.GetSection("PrestashopSettings").GetSection("ApiKey").Value;
+
+            card.Body.Insert(0,new AdaptiveImage
+            {
+                Url = new Uri(Image.Url +$"?ws_key={apiKey}")
+            });
+
+            return card;
+        }
+    }
+
+}

--- a/Store/IPrestashopApi.cs
+++ b/Store/IPrestashopApi.cs
@@ -11,5 +11,11 @@ namespace CoreBot.Store
 
         [Get("/customers?display=[id,passwd,lastname,firstname,email,date_upd]&filter[id]={id}")]
         Task<CustomerCollection> GetCustomerById(int id);
+
+        [Get("/customers?display=[id,passwd,lastname,firstname,email,date_upd]&filter[firstname]={firstname}&filter[lastname]={lastname}")]
+        Task<CustomerCollection> GetCustomerByFullName(string firstname, string lastname);
+
+        [Get("/customers?display=[id,passwd,lastname,firstname,email,date_upd]&filter[firstname]={firstname}")]
+        Task<CustomerCollection> GetCustomerByFirstName(string firstname);
     }
 }

--- a/Store/IPrestashopApi.cs
+++ b/Store/IPrestashopApi.cs
@@ -9,13 +9,16 @@ namespace CoreBot.Store
         [Get("/products?display=[id,name,description,id_default_image]&filter[name]=%[{product}]%")]
         Task<ProductCollection> GetProductByName(string product);
 
-        [Get("/customers?display=[id,passwd,lastname,firstname,email,date_upd]&filter[id]={id}")]
+        [Get("/products?display=[id,name,description,id_default_image]&filter[id]={id}%")]
+        Task<ProductCollection> GetProductById(int id);
+
+        [Get("/customers?display=[id,passwd,lastname,firstname,email,company,date_upd]&filter[id]={id}")]
         Task<CustomerCollection> GetCustomerById(int id);
 
-        [Get("/customers?display=[id,passwd,lastname,firstname,email,date_upd]&filter[firstname]={firstname}&filter[lastname]={lastname}")]
+        [Get("/customers?display=[id,passwd,lastname,firstname,email,company,date_upd]&filter[firstname]=%[{firstname}]%&filter[lastname]=%[{lastname}]%")]
         Task<CustomerCollection> GetCustomerByFullName(string firstname, string lastname);
 
-        [Get("/customers?display=[id,passwd,lastname,firstname,email,date_upd]&filter[firstname]={firstname}")]
+        [Get("/customers?display=[id,passwd,lastname,firstname,email,company,date_upd]&filter[firstname]=%[{firstname}]%")]
         Task<CustomerCollection> GetCustomerByFirstName(string firstname);
     }
 }

--- a/Store/ImageCarouselable.cs
+++ b/Store/ImageCarouselable.cs
@@ -1,35 +1,20 @@
 ﻿using AdaptiveCards;
-using CoreBot.Store.Entity;
 using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Configuration;
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using System.Xml.Serialization;
 
 namespace CoreBot.Store
 {
     /// <summary>
-    /// A container whose elements can be displayed in a carousel of attachments.
+    /// A container whose elements can be displayed in a carousel of attachments which get their images from Prestashop Urls.
     /// </summary>
-    public class Carouselable<T> where T : IAttachable
+    public class ImageCarouselable<T> : Carouselable<T> where T : IImageAttachable
     {
-        [XmlIgnore]
-        public T[] Elements { get; set; }
-
-        public Attachment[] ToCarousel()
-        {
-            int i = 0;
-            List<Attachment> attachments = new List<Attachment>();
-
-            while (i < Elements.Length)
-            {
-                attachments.Add(Elements[i].ToAttachment());
-                i++;
-            }
-
-            return attachments.ToArray();
-        }
-
-        public Attachment[] ToSelectionCarousel()
+        public Attachment[] ToSelectionCarousel(IConfiguration configuration)
         {
             int i = 0;
             List<Attachment> attachments = new List<Attachment>();
@@ -37,7 +22,7 @@ namespace CoreBot.Store
 
             while (i < Elements.Length)
             {
-                var card = Elements[i].ToAdaptiveCard();
+                var card = Elements[i].ToImageAdaptiveCard(configuration);
                 card.Actions.Add(new AdaptiveSubmitAction
                 {
                     Title = "SELECT",
@@ -55,11 +40,6 @@ namespace CoreBot.Store
             }
 
             return attachments.ToArray();
-        }
-
-        public T First()
-        {
-            return Elements.Length > 0 ? Elements[0] : null;
         }
     }
 }

--- a/Utilities/CardUtils.cs
+++ b/Utilities/CardUtils.cs
@@ -4,14 +4,19 @@ using CoreBot.Store.Entity;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Configuration;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace CoreBot.Utilities
 {
+    /// <summary>
+    /// Collection of static methods for custom Card operations.
+    /// </summary>
     public static class CardUtils
     {
         public const string sameCardMsg = "Don't use the same Submit Card twice. If you want to submit new data ask for the Card again.";
@@ -34,39 +39,6 @@ namespace CoreBot.Utilities
                 Content = card
             };
             return resposta;
-        }
-
-
-        public static List<Attachment> CarouselFromProducts(ProductCollection collection, IConfiguration configuration)
-        {
-            List<Product> products = collection.Products.ToList();
-            List<Attachment> attachments = new List<Attachment>();
-            var apiKey = configuration.GetSection("PrestashopSettings").GetSection("ApiKey").Value;
-            Guid guid = Guid.NewGuid();
-            int index = 0;
-
-
-            foreach(Product product in products)
-            {
-                var heroCard = new HeroCard
-                {
-                    Title = $"<b>{product.GetNameByLanguage(ENGLISH)}</b>",
-                    Text = product.GetDescriptionByLanguage(ENGLISH),
-                    Images = new List<CardImage> { new CardImage(product.Image.Url+"?ws_key="+apiKey) },
-                    Buttons = new List<CardAction> { new CardAction {
-                        Type = ActionTypes.PostBack,
-                        Title = "Choose", 
-                        Value = $@"{{ ""id"" : ""{guid.ToString()}"", ""action"" : ""{index}""}}"
-                        }
-                    }
-                };
-
-                attachments.Add(heroCard.ToAttachment());
-
-                index++;
-            }
-
-            return attachments;
         }
 
         public static Attachment CreateCardFromOrder(UserProfile userProfile)
@@ -134,6 +106,18 @@ namespace CoreBot.Utilities
                 Content = card,
                 ContentType = "application/vnd.microsoft.card.adaptive"
             };
+        }
+
+        public static T GetValueFromAction<T>(string json) where T : IConvertible
+        {
+            var jobject = JObject.Parse(json);
+            return (T)Convert.ChangeType(jobject["action"], typeof(T), CultureInfo.InvariantCulture);
+        }
+
+        public static string GetGuidFromResult(string card)
+        {
+            var jobject = JObject.Parse(card);
+            return (string)jobject["id"];
         }
 
         static public string AddGuidToJson(string json)

--- a/Utilities/CardUtils.cs
+++ b/Utilities/CardUtils.cs
@@ -15,7 +15,7 @@ namespace CoreBot.Utilities
     public static class CardUtils
     {
         public const string sameCardMsg = "Don't use the same Submit Card twice. If you want to submit new data ask for the Card again.";
-        private const int ENGLISH = 7;
+        public const int ENGLISH = 7;
 
         public static Attachment CreateCardFromProductInfo(ProductInfo productInfo)
         {
@@ -71,10 +71,7 @@ namespace CoreBot.Utilities
 
         public static Attachment CreateCardFromOrder(UserProfile userProfile)
         {
-            string[] paths = { ".", "Cards", "confirmOrderCard.json" };
-            var cardJson = File.ReadAllText(Path.Combine(paths));
-            var processedJson = AddGuidToJson(cardJson);
-            var card = AdaptiveCard.FromJson(processedJson).Card;
+            var card = CreateCardFromJson("confirmOrderCard");
 
             //Ara hem convertit el JSON a un AdaptiveCard i editarem els fragments que ens interessen.
 
@@ -120,6 +117,23 @@ namespace CoreBot.Utilities
             };
 
             return attachment;
+        }
+
+        static public AdaptiveCard CreateCardFromJson(string json)
+        {
+            string[] paths = { ".", "Cards", json+".json" };
+            var cardJson = File.ReadAllText(Path.Combine(paths));
+            var processedJson = AddGuidToJson(cardJson);
+            return AdaptiveCard.FromJson(processedJson).Card;
+        }
+
+        static public Attachment AdaptiveCardToAttachment(AdaptiveCard card)
+        {
+            return new Attachment
+            {
+                Content = card,
+                ContentType = "application/vnd.microsoft.card.adaptive"
+            };
         }
 
         static public string AddGuidToJson(string json)


### PR DESCRIPTION
### Rendering Interfaces
In order to display some entities as AdaptiveCards, I've created some interfaces that contain functions to render said entities (Prestashop Entities) and removed the previous implemented logic from `CardUtils.cs`. The new interfaces are:
- **IAttachable**: Represents an item that can be converted to Attachment / Adaptive Card.
- **IImageAttachable** : Represents an item that can be converted to Attachment / Adaptive card and contains an item. So it has special functions to access the Prestashop image API.
- **ICarouselable**: Represents a collection of `IAttachable` items that can be displayed as one single Carousel of items.
- **IImageCarouselable**: Like `ICarouselable` but contains `IImageAttachable` objects.

### EF Core Integration
Added integration for the AzureDB through the EF Core ORM. Removed previous query logic from Dialog classes. The `GretaDBContext` service is available in `Startup.cs` as a Scoped service. Dialogs can get it using the `IServiceProvider` interface. The DbContext contains as of now:
- **UserProfile**
- **NAQuestions**

The `OrderLine` class will be replaced soon by the PrestaShop counterpart, that will have its own Serializable entity.

### UserValidationDialog
Added a Dialog in which _SUPERUSER_ users will have the ability to add new customers to the service. The sequence flow works as follows:
- The user is asked for the new user name (optionally Id, or first name).
- Potential search matches are displayed to the user to choose from.
- The user is asked to assing a level of permission for the new user.
- If all goes correctly a new user is created.

### QoL
- Added extension methods to avoid casting every time I want to pass an object from step to step in a Waterfall.
- Added methods to retrieve ids and actions from card Submit results.
- Removed repeating code in some classes and made generic functions for maintainability.