### PR TITLE
Added xml serializers for Prestashop entities

### DIFF
--- a/Dialogs/OrderProductDialog.cs
+++ b/Dialogs/OrderProductDialog.cs
@@ -126,6 +126,8 @@ namespace CoreBot.Dialogs
 
         private async Task<DialogTurnResult> AddToCartStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
+            //TO_DO Add Order to Prestashop
+
             var singleOrder = (SingleOrder)stepContext.Options;
 
             if ((bool)stepContext.Result)

--- a/Extensions/ApiCallerExtensions.cs
+++ b/Extensions/ApiCallerExtensions.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using CoreBot.Store;
+
+namespace CoreBot.Extensions
+{
+    public static class ApiCallerExtensions
+    {
+        public static string ToQueryListParameter<T>(this List<T> tList) where T : IIdentifiable
+        {
+            if (tList.Count == 0) throw new EmptyParameterListException("List cannot be empty");
+
+            string list = "[";
+            int count = 0;
+
+            foreach (T element in tList)
+            {
+                list += element.Id;
+                count++;
+                list += (count != tList.Count) ? "," : "";
+            }
+
+            return (list + "]");
+        }
+    }
+
+    public class EmptyParameterListException : Exception
+    {
+        public EmptyParameterListException(string message) : base(message)
+        {
+
+        }
+    }
+}

--- a/Store/Entity/Address.cs
+++ b/Store/Entity/Address.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+
+namespace CoreBot.Store.Entity
+{
+    public class Address
+    {
+        [XmlElement("id")]
+        public int Id { get; set; }
+
+        //TODO COUNTRY
+
+        [XmlElement("alias")]
+        public string Alias { get; set; }
+
+        [XmlElement("lastname")]
+        public string LastName { get; set; }
+
+        [XmlElement("firstname")]
+        public string FirstName { get; set; }
+
+        [XmlElement("city")]
+        public string City { get; set; }
+    }
+}

--- a/Store/Entity/Cart.cs
+++ b/Store/Entity/Cart.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+
+namespace CoreBot.Store.Entity
+{
+    public class Cart : IIdentifiable
+    {
+        public override int Id { get; set; }
+
+        //public int DeliveryAddressId { get; set; }
+
+        //public int AdressInvoiceId { get; set; }
+        
+        public int CurrencyId { get; set; }
+
+        //public int GuestId { get; set; }
+
+        public int LanguageId { get; set; }
+
+        [XmlElement("associations")]
+        public CartRowCollection Rows { get; set; }
+    }
+
+    public class CartRowCollection
+    {
+        public CartRowCollection()
+        {
+            Rows = new List<CartRow>();
+        }
+
+        [XmlArray("cart_rows")]
+        [XmlArrayItem("cart_row")]
+        public List<CartRow> Rows { get; set; }
+    }
+
+    public class CartRow
+    {
+        public CartRow()
+        {
+        }
+
+        public Product Product;
+
+        private int? _productId { get; set; }
+
+        [XmlElement("id_product")]
+        public int ProductId
+        {
+            get { return _productId ?? Product.Id; }
+            set { _productId = value; }
+        }
+
+        [XmlElement("id_product_attribute")]
+        public int CombinationId { get; set; }
+
+        [XmlElement("quantity")]
+        public int Quantity { get; set; }
+    }
+}

--- a/Store/Entity/Country.cs
+++ b/Store/Entity/Country.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+
+namespace CoreBot.Store.Entity
+{
+    public class Country : IIdentifiable
+    {
+        [XmlElement("id")]
+        public override int Id { get; set; }
+
+        private int? _zoneId { get; set; }
+
+        [XmlElement("id_zone")]
+        public int ZoneId
+        {
+            get { return _zoneId ?? Zone.Id; }
+            set { _zoneId = value; }
+        }
+
+        public Zone Zone { get; set; }
+
+        private int? _currencyId { get; set; }
+
+        [XmlElement("id_currency")]
+        public int CurrencyId
+        {
+            get { return _currencyId ?? Currency.Id; }
+            set { _currencyId = value; }
+        }
+
+        public Currency Currency { get; set; }
+
+        [XmlElement("contains_states")]
+        public byte ContainsStates { get; set; }
+
+        [XmlElement("need_identification_number")]
+        public byte NeedIdentificationNumber { get; set; }
+
+        [XmlElement("display_tax_label")]
+        public byte DisplayTaxLabel { get; set; }
+
+        [XmlArray("name")]
+        [XmlArrayItem("language", typeof(LanguageTraduction))]
+        public List<LanguageTraduction> Description { get; }
+    }
+
+    public class Zone : IIdentifiable
+    {
+        [XmlElement("id")]
+        public override int Id { get; set; }
+
+        [XmlElement("name")]
+        public string Name { get; set; }
+    }
+
+    public class Currency : IIdentifiable
+    {
+        [XmlElement("id")]
+        public override int Id { get; set; }
+
+        [XmlElement("name")]
+        public string Name { get; set; }
+
+        [XmlElement("iso_code")]
+        public string IsoCode { get; set; }
+
+        [XmlElement("conversion_rate")]
+        public float ConversionRate { get; set; }
+
+        [ContractInvariantMethod]
+        protected void ObjectInvariant()
+        {
+            Contract.Invariant(this.IsoCode.Length == 3);
+        }
+    }
+}

--- a/Store/Entity/Customer.cs
+++ b/Store/Entity/Customer.cs
@@ -9,6 +9,9 @@ namespace CoreBot.Store.Entity
         [XmlElement("id")]
         public override int Id { get; set; }
 
+        [XmlElement("id_lang")]
+        public CustomerLanguage Language { get; set; }
+
         [XmlElement("passwd")]
         public string Password { get; set; }
 
@@ -49,6 +52,15 @@ namespace CoreBot.Store.Entity
 
             return card;
         }
+    }
+
+    public class CustomerLanguage
+    {
+        [XmlText]
+        public int Id { get; set; }
+
+        [XmlAttribute("href", Namespace = "http://www.w3.org/1999/xlink")]
+        public string Url { get; set; }
     }
 
     [XmlRoot("prestashop")]

--- a/Store/Entity/Language.cs
+++ b/Store/Entity/Language.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+
+namespace CoreBot.Store.Entity
+{
+    [XmlRoot("prestashop")]
+    public class Language
+    {
+        [XmlElement("id")]
+        public int Id { get; set; }
+
+        [XmlElement("name")]
+        public string Name { get; set; }
+
+        [XmlElement("iso_code")]
+        public string IsoCode { get; set; }
+
+        [XmlElement("locale")]
+        public string Locale { get; set; }
+
+        [XmlElement("language_code")]
+        public string LanguageCode { get; set; }
+
+        [XmlElement("active")]
+        public byte IsActive { get; set; }
+    }
+}

--- a/Store/Entity/Order.cs
+++ b/Store/Entity/Order.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+
+namespace CoreBot.Store.Entity
+{
+    public class Order : IIdentifiable
+    {
+        public Order(Customer customer, Cart cart, Address deliveryAddress, Address invoiceAddress)
+        {
+            Customer = customer;
+            Cart = cart;
+            DeliveryAddress = deliveryAddress;
+            InvoiceAddress = invoiceAddress;
+        }
+
+        [XmlIgnore]
+        public Customer Customer { get; set; }
+
+        [XmlIgnore]
+        public Cart Cart { get; set; }
+
+        [XmlIgnore]
+        public Address DeliveryAddress { get; set; }
+
+        [XmlIgnore]
+        public Address InvoiceAddress { get; set; }
+
+        [XmlElement("id")]
+        public override int Id { get; set; }
+
+        private int? _deliveryAddressId { get; set; }
+
+        [XmlElement("id_address_delivery")]
+        public int DeliveryAddressId
+        {
+            get { return _deliveryAddressId ?? DeliveryAddress.Id; }
+            set { _deliveryAddressId = value; }
+        }
+
+        private int? _invoiceAddressId { get; set; }
+
+        [XmlElement("id_address_invoice")]
+        public int? InvoiceAddressId
+        {
+            get { return _invoiceAddressId ?? InvoiceAddress.Id; }
+            set { _invoiceAddressId = value; }
+        }
+
+        private int? _cartId { get; set; }
+
+        [XmlElement("id_cart")]
+        public int CartId
+        {
+            get { return _cartId ?? Cart.Id; }
+            set { _cartId = value; }
+        }
+
+        private int? _customerId { get; set; }
+
+        [XmlElement("id_customer")]
+        public int CustomerId
+        {
+            get { return _customerId ?? Customer.Id; }
+            set { _customerId = value; }
+        }
+
+        [XmlElement("payment")]
+        public string Payment { get; set; }
+
+        [XmlElement("total_paid_real")]
+        public float TotalPayedReal { get; set; }
+
+        [XmlElement("total_products")]
+        public float TotalProducts { get; set; }
+
+        [XmlElement("total_products_wt")]
+        public float TotalProductsWithoutTax { get; set; }
+
+        [XmlElement("conversion_rate")]
+        public float ConversionRate { get; set; }
+
+        /*[XmlElement("associations")]
+        public OrderRows OrderRows { get; set; }*/
+    }
+
+    public class OrderRows
+    {
+        [XmlArray("order_rows")]
+        [XmlArrayItem("order_row")]
+        public List<OrderRow> Rows { get; set; }
+    }
+
+    public class OrderRow
+    {
+        public OrderRow(Product product, int quantity)
+        {
+            _product = product;
+            Quantity = quantity;
+            AttributeId = 0;
+        }
+
+        private Product _product;
+
+        private int? _productId { get; set; }
+
+        [XmlElement("product_id")]
+        public int ProductId
+        {
+            get { return _productId ?? _product.Id; }
+            set { _productId = value; }
+        }
+
+        [XmlElement("product_attribute_id")]
+        public int AttributeId { get; set; }
+
+        [XmlElement("quantity")]
+        public int Quantity { get; set; }
+    }
+}

--- a/Store/Entity/OrderDetail.cs
+++ b/Store/Entity/OrderDetail.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+
+namespace CoreBot.Store.Entity
+{
+    public class OrderDetail
+    {
+        public OrderDetail(Product product, Order order)
+        {
+            _product = product;
+            _order = order;
+        }
+
+        private Product _product;
+        private Order _order;
+
+
+        [XmlElement("id")]
+        public int Id { get; set; }
+
+        [XmlElement("product_id")]
+        public int ProductId
+        {
+            get { return _product.Id; }
+        }
+
+        [XmlIgnore]
+        public Product Product
+        {
+            get { return _product; }
+            set { _product = value; }
+        }
+
+        [XmlIgnore]
+        public Order Order
+        {
+            get { return _order; }
+            set { _order = value; }
+        }
+
+        private string _productName { get; set; }
+
+        [XmlElement("product_name")]
+        public string ProductName
+        {
+            get { return _productName ?? _product.GetNameByLanguage(_order.Customer.Language.Id); }
+            set { _productName = value; }
+        }
+
+        private float? _productPrice { get; set; }
+
+        [XmlElement("product_price")]
+        public float ProductPrice
+        {
+            get { return _productPrice ?? _product.Price; }
+            set { _productPrice = value; }
+        }
+
+        private float? _productWeight { get; set; }
+
+        [XmlElement("product_weight")]
+        public float ProductWeight
+        {
+            get { return _productWeight ?? _product.Weight; }
+            set { _productWeight = value; }
+        }
+    }
+}

--- a/Store/Entity/Product.cs
+++ b/Store/Entity/Product.cs
@@ -2,6 +2,7 @@
 using CoreBot.Utilities;
 using Microsoft.Bot.Schema;
 using System;
+using System.Collections.Generic;
 using System.Xml.Serialization;
 
 namespace CoreBot.Store.Entity
@@ -14,17 +15,23 @@ namespace CoreBot.Store.Entity
         [XmlElement("id_default_image")]
         public override Image Image { get; set; }
 
+        [XmlElement("weight")]
+        public float Weight { get; set; }
+        
+        [XmlElement("price")]
+        public float Price { get; set; }
+
         [XmlArray("name")]
-        [XmlArrayItem("language", typeof(Language))]
-        public Language[] Name { get; set; }
+        [XmlArrayItem("language", typeof(LanguageTraduction))]
+        public List<LanguageTraduction> Name { get; set; }
 
         [XmlArray("description")]
-        [XmlArrayItem("language", typeof(Language))]
-        public Language[] Description { get; set; }
+        [XmlArrayItem("language", typeof(LanguageTraduction))]
+        public List<LanguageTraduction> Description { get; set; }
 
         public string GetNameByLanguage(int language)
         {
-            foreach(Language l in Name)
+            foreach(LanguageTraduction l in Name)
             {
                 if (l.Id == language) return l.Text;
             }
@@ -34,7 +41,7 @@ namespace CoreBot.Store.Entity
 
         public string GetDescriptionByLanguage(int language)
         {
-            foreach (Language l in Description)
+            foreach (LanguageTraduction l in Description)
             {
                 if (l.Id == language) return l.Text;
             }
@@ -56,7 +63,7 @@ namespace CoreBot.Store.Entity
         }
     }
 
-    public class Language
+    public class LanguageTraduction
     {
         [XmlAttribute("id")]
         public int Id { get; set; }

--- a/Store/IAttachable.cs
+++ b/Store/IAttachable.cs
@@ -12,10 +12,10 @@ namespace CoreBot.Store.Entity
     /// <summary>
     /// Represents an object that can be rendered as an Adaptive attachment.
     /// </summary>
-    public abstract class IAttachable
+    public abstract class IAttachable : IIdentifiable
     {
         [XmlIgnore]
-        public abstract int Id { get; set; }
+        public override abstract int Id { get; set; }
         public Attachment ToAttachment()
         {
             return CardUtils.AdaptiveCardToAttachment(ToAdaptiveCard());

--- a/Store/IIdentifiable.cs
+++ b/Store/IIdentifiable.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace CoreBot.Store
+{
+    public abstract class IIdentifiable
+    {
+        public abstract int Id { get; set; }
+    }
+}

--- a/Store/IPrestashopApi.cs
+++ b/Store/IPrestashopApi.cs
@@ -12,13 +12,13 @@ namespace CoreBot.Store
         [Get("/products?display=[id,name,description,id_default_image]&filter[id]={id}%")]
         Task<ProductCollection> GetProductById(int id);
 
-        [Get("/customers?display=[id,passwd,lastname,firstname,email,company,date_upd]&filter[id]={id}")]
+        [Get("/customers?display=[id,id_lang,passwd,lastname,firstname,email,company,date_upd]&filter[id]={id}")]
         Task<CustomerCollection> GetCustomerById(int id);
 
-        [Get("/customers?display=[id,passwd,lastname,firstname,email,company,date_upd]&filter[firstname]=%[{firstname}]%&filter[lastname]=%[{lastname}]%")]
+        [Get("/customers?display=[id,id_lang,passwd,lastname,firstname,email,company,date_upd]&filter[firstname]=%[{firstname}]%&filter[lastname]=%[{lastname}]%")]
         Task<CustomerCollection> GetCustomerByFullName(string firstname, string lastname);
 
-        [Get("/customers?display=[id,passwd,lastname,firstname,email,company,date_upd]&filter[firstname]=%[{firstname}]%")]
+        [Get("/customers?display=[id,id_lang,passwd,lastname,firstname,email,company,date_upd]&filter[firstname]=%[{firstname}]%")]
         Task<CustomerCollection> GetCustomerByFirstName(string firstname);
     }
 }


### PR DESCRIPTION
Added xml de/serializers for the following entities:
- Address
- Currency
- Country
- Cart
- Order
- Order Lines
- Customer

Added simple logic to parse an array of prestashop entities to an array of Query parameters.
List<IIdentifiable> is converted to `[1,2,3,4]` where _1,2,3,4_ are the Ids of said objects. In order to easily query something like: `/products?filter[id]=[1,2,3,4]`
