### PR TITLE
User Login and Permission remodelling

### DIFF
--- a/Bots/GretaBot.cs
+++ b/Bots/GretaBot.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System.Collections.Concurrent;
+using System.Threading;
 using System.Threading.Tasks;
 using CoreBot.Utilities;
 using Microsoft.Bot.Builder;
@@ -9,26 +10,31 @@ using Newtonsoft.Json.Linq;
 
 namespace CoreBot.Bots
 {
-    public class GretaBot<T> : IBot
+    public class GretaBot<T> : ActivityHandler
         where T : Dialog
     {
         private readonly Dialog Dialog;
         private readonly BotState _conversationState;
         private readonly BotState _userState;
+        private readonly ConcurrentDictionary<string, ConversationReference> _conversationReferences;
         private const string askingMsg = "If you want me to perform an action for you just ask it straight forward. You can say things like:\n- I want to log in.\n- I want to order vitrocool.\n- Show me my shopping card.\n- What products can I buy?";
-        private const string cancelMsg = "Once we start a conversation (let's say you want to order something and I start asking things) and you want to cancel, you can say something like *cancel* or *quit* to exit the current operation.";
-        private const string helpMsg = "Also, if you don't know what's happening just type *?* or *help* and I will try to explain what is going on!";
+        private const string cancelMsg = "Once we start a conversation (let's say you want to order something and I start asking things) and you want to cancel, you can say something like **cancel** or **quit** to exit the current operation.";
+        private const string helpMsg = "Also, if you don't know what's happening just type **?** or **help** and I will try to explain what is going on!";
 
-        public GretaBot(ConversationState conversationState, UserState userState, T dialog)
+        public GretaBot(ConversationState conversationState, UserState userState, T dialog,
+            ConcurrentDictionary<string, ConversationReference> conversationReferences)
         {
             _conversationState = conversationState;
             _userState = userState;
+            _conversationReferences = conversationReferences;
             Dialog = dialog;
         }
 
-        public async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken)
+        public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken)
         {
             var activity = turnContext.Activity;
+
+            AddConversationReference(activity);
 
             // If the message comes from an Adaptive Card we serialize the answer and send it as a message.
             if(string.IsNullOrWhiteSpace(activity.Text) && activity.Value != null)
@@ -59,6 +65,19 @@ namespace CoreBot.Bots
             // Save any changes on the User/Conversation State.
             await _userState.SaveChangesAsync(turnContext);
             await _conversationState.SaveChangesAsync(turnContext);
+        }
+
+        protected override Task OnConversationUpdateActivityAsync(ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
+        {
+            AddConversationReference(turnContext.Activity as Activity);
+
+            return base.OnConversationUpdateActivityAsync(turnContext, cancellationToken);
+        }
+
+        private void AddConversationReference(Activity activity)
+        {
+            var conversationReference = activity.GetConversationReference();
+            _conversationReferences.AddOrUpdate(conversationReference.User.Id, conversationReference, (key, newValue) => conversationReference);
         }
 
 

--- a/Bots/GretaBot.cs
+++ b/Bots/GretaBot.cs
@@ -15,6 +15,9 @@ namespace CoreBot.Bots
         private readonly Dialog Dialog;
         private readonly BotState _conversationState;
         private readonly BotState _userState;
+        private const string askingMsg = "If you want me to perform an action for you just ask it straight forward. You can say things like:\n- I want to log in.\n- I want to order vitrocool.\n- Show me my shopping card.\n- What products can I buy?";
+        private const string cancelMsg = "Once we start a conversation (let's say you want to order something and I start asking things) and you want to cancel, you can say something like *cancel* or *quit* to exit the current operation.";
+        private const string helpMsg = "Also, if you don't know what's happening just type *?* or *help* and I will try to explain what is going on!";
 
         public GretaBot(ConversationState conversationState, UserState userState, T dialog)
         {
@@ -35,7 +38,10 @@ namespace CoreBot.Bots
 
                 var jobject = (JObject)activity.Value;
 
-                if (conversationData.DisabledCards.ContainsKey((string)jobject["id"]))
+                if (jobject["id"].ToString().StartsWith("Greta"))
+                    await SendGretaHelpMessageAsync(turnContext);
+
+                else if (conversationData.DisabledCards.ContainsKey((string)jobject["id"]))
                 {
                     await turnContext.SendActivityAsync(MessageFactory.Text(CardUtils.sameCardMsg), cancellationToken);
                 }
@@ -53,6 +59,26 @@ namespace CoreBot.Bots
             // Save any changes on the User/Conversation State.
             await _userState.SaveChangesAsync(turnContext);
             await _conversationState.SaveChangesAsync(turnContext);
+        }
+
+
+        public static async Task SendGretaHelpMessageAsync(ITurnContext turnContext)
+        {
+            var json = (JObject)turnContext.Activity.Value;
+            var code = (string)json["id"];
+
+            switch (code)
+            {
+                case "GretaMoreInfo":
+                    await turnContext.SendActivityAsync(askingMsg);
+                    await turnContext.SendActivityAsync(cancelMsg);
+                    await turnContext.SendActivityAsync(helpMsg);
+                    break;
+
+                case "GretaActions":
+                    await turnContext.SendActivityAsync("TO_DO");
+                    break;
+            }
         }
     }
 }

--- a/Cards/gretaWelcomeCard.json
+++ b/Cards/gretaWelcomeCard.json
@@ -1,0 +1,45 @@
+{
+  "type": "AdaptiveCard",
+  "body": [
+    {
+      "type": "Image",
+      "url": "https://i.imgur.com/5EVSOq0.jpg",
+      "size": "stretch"
+    },
+    {
+      "type": "TextBlock",
+      "weight": "bolder",
+      "size": "default",
+      "text": "Hi, I'm Greta! The VITROSEP virtual assistant"
+    },
+    {
+      "type": "TextBlock",
+      "isSubtle": "true",
+      "wrap": "true",
+      "text": "I've been designed to provide a complete and user-friendly experience of our services. I can give you information about our products and even order them for you! If you want more information use the buttons below or start chatting!"
+    }
+  ],
+  "actions": [
+    {
+      "type": "Action.Submit",
+      "title": "How to ask me things",
+      "data": {
+        "id": "GretaMoreInfo"
+      }
+    },
+    {
+      "type": "Action.Submit",
+      "title": "What can I do?",
+      "data": {
+        "id": "GretaActions"
+      }
+    },
+    {
+      "type": "Action.OpenUrl",
+      "title": "Register in VitrosepStore",
+      "url": "https://vitrosepstore.com/en/login?create_account=1"
+    }
+  ],
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.0"
+}

--- a/Cards/submitPassword.json
+++ b/Cards/submitPassword.json
@@ -1,0 +1,49 @@
+{
+  "type": "AdaptiveCard",
+  "body": [
+    {
+      "type": "Container",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "ENTER YOUR PASSWORD",
+          "weight": "bolder",
+          "size": "large",
+          "horizontalAlignment": "center"
+        }
+      ]
+    },
+    {
+      "type": "TextBlock",
+      "separator": "true",
+      "wrap": "true",
+      "text": "In order to use all the functionalities we need to verify you're a registered user. Please enter your VitrosepStore password.",
+      "spacing": "medium"
+
+    },
+    {
+      "id": "action",
+      "type": "Input.Text",
+      "separator": "true",
+      "spacing": "medium",
+      "placeholder": "Password"
+    },
+    {
+      "type": "TextBlock",
+      "text": "*Once you submit the password you can delete it from the screen.",
+      "wrap": "true",
+      "isSubtle": "true"
+    }
+  ],
+  "actions": [
+    {
+      "type": "Action.Submit",
+      "title": "Submit Password",
+      "data": {
+        "id": "submitButton1"
+      }
+    }
+  ],
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.0"
+}

--- a/Controllers/NotifyController.cs
+++ b/Controllers/NotifyController.cs
@@ -1,0 +1,74 @@
+﻿using CoreBot.Models;
+using CoreBot.Store;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CoreBot.Controllers
+{
+    public class NotifyController
+    {
+        private readonly IBotFrameworkHttpAdapter _adapter;
+        private readonly string _appId;
+        private readonly ConcurrentDictionary<string, ConversationReference> _conversationReferences;
+        private readonly IPrestashopApi PrestashopApi;
+        private readonly UserController UserController;
+
+        public NotifyController(IBotFrameworkHttpAdapter adapter, ConcurrentDictionary<string,ConversationReference> references,
+            UserController userController, IConfiguration configuration, IPrestashopApi prestashopApi)
+        {
+            _adapter = adapter;
+            _conversationReferences = references;
+            UserController = userController;
+            _appId = configuration["MicrosoftAppId"];
+            PrestashopApi = prestashopApi;
+
+            if (string.IsNullOrEmpty(_appId))
+            {
+                _appId = Guid.NewGuid().ToString(); //if no AppId, use a random Guid
+            }
+        }
+
+        public async Task RequestValidationAsync(string id)
+        {
+            var superusers = await UserController.GetUsersByPermissionLevelAsync(0);
+
+            var requestingUser = await UserController.GetUserByBotIdAsync(id);
+
+            var prestashopUser = (await PrestashopApi.GetCustomerById(requestingUser.PrestashopId.Value)).First();
+
+            // We declare a local function to use as BotCallBackHandler in the ContinueConversationAsync Method
+            async Task botCallBack(ITurnContext turnContext, CancellationToken cancellationToken) =>
+                    await turnContext.SendActivityAsync($"User {prestashopUser.GetFullName()} would like to get his account validated.");
+
+            foreach (Models.UserProfile superuser in superusers)
+            {
+                var conversationReference = _conversationReferences[superuser.BotUserId];
+
+                await ((BotAdapter)_adapter).ContinueConversationAsync(_appId, conversationReference, botCallBack, default);
+            }
+        }
+
+
+        public async Task NotifyValidation(int prestashopId)
+        {
+            var user = await UserController.GetUserByPrestashopIdAsync(prestashopId);
+
+            var conversationReference = _conversationReferences[user.BotUserId];
+
+            async Task botCallBack(ITurnContext turnContext, CancellationToken cancellationToken) =>
+                    await turnContext.SendActivityAsync("Your account has been validated, you can start using Greta in its full potential!");
+
+            await ((BotAdapter)_adapter).ContinueConversationAsync(_appId, conversationReference, botCallBack, default);
+        }
+    }
+}

--- a/Controllers/NotifyController.cs
+++ b/Controllers/NotifyController.cs
@@ -66,7 +66,7 @@ namespace CoreBot.Controllers
             var conversationReference = _conversationReferences[user.BotUserId];
 
             async Task botCallBack(ITurnContext turnContext, CancellationToken cancellationToken) =>
-                    await turnContext.SendActivityAsync("Your account has been validated, you can start using Greta in its full potential!");
+                    await turnContext.SendActivityAsync("Your account has been validated.\n If you want to log in now say something like **I want to log in** or **Let me authenticate**, and you will be ready to enjoy all our services!\n You can always log in later.");
 
             await ((BotAdapter)_adapter).ContinueConversationAsync(_appId, conversationReference, botCallBack, default);
         }

--- a/Controllers/QuestionController.cs
+++ b/Controllers/QuestionController.cs
@@ -1,0 +1,38 @@
+﻿using CoreBot.Models;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace CoreBot.Controllers
+{
+    public class QuestionController
+    {
+        private readonly UserController UserController;
+        private readonly IServiceProvider ServiceProvider;
+
+        public QuestionController(IServiceProvider serviceProvider, UserController userController)
+        {
+            UserController = userController;
+            ServiceProvider = serviceProvider;
+        }
+
+        public async Task AddQuestionAsync(string question, string botId)
+        {
+            var user = await UserController.GetUserByBotIdAsync(botId);
+
+            using (var scope = ServiceProvider.CreateScope())
+            {
+                var db = scope.ServiceProvider.GetRequiredService<GretaDBContext>();
+
+                user.Naquestions.Add(new Naquestions()
+                {
+                    QuestionText = question
+                });
+
+                await db.SaveChangesAsync();
+            }
+        }
+    }
+}

--- a/Controllers/UserController.cs
+++ b/Controllers/UserController.cs
@@ -1,0 +1,95 @@
+﻿using CoreBot.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace CoreBot.Controllers
+{
+    public class UserController
+    {
+        private readonly IServiceProvider ServiceProvider;
+
+        public UserController(IServiceProvider serviceProvider)
+        {
+            ServiceProvider = serviceProvider;
+        }
+
+        //TO_DO TFG EXPLICAR FUNCIONS ASÍNCRONES
+
+        public async Task AddUserAsync(Models.UserProfile userProfile)
+        {
+            using (var context = ServiceProvider.CreateScope())
+            {
+                var db = context.ServiceProvider.GetRequiredService<GretaDBContext>();
+
+                db.Add(userProfile);
+                await db.SaveChangesAsync();
+            }
+        }
+
+        public async Task<List<Models.UserProfile>> GetUsersByPermissionLevelAsync(int permissionLevel)
+        {
+            using (var context = ServiceProvider.CreateScope())
+            {
+                var db = context.ServiceProvider.GetRequiredService<GretaDBContext>();
+
+                return await db.UserProfile.Where(u => u.Permission == permissionLevel && u.BotUserId != null).ToListAsync();
+            }
+        }
+
+
+        public async Task<bool> CheckForUserProfileAsync(int prestaId)
+        {
+            var user = await GetUserByPrestashopIdAsync(prestaId);
+            return await Task.FromResult(user != null);
+        }
+
+
+        public async Task<bool> CheckForUserProfileAsync(string botId)
+        {
+            var user = await GetUserByBotIdAsync(botId);
+            return await Task.FromResult(user != null);
+        }
+
+
+        public async Task<Models.UserProfile> GetUserByPrestashopIdAsync(int prestashopId)
+        {
+            using (var context = ServiceProvider.CreateScope())
+            {
+                var db = context.ServiceProvider.GetRequiredService<GretaDBContext>();
+
+                return await db.UserProfile.Where(u => u.PrestashopId == prestashopId).FirstOrDefaultAsync();
+            }
+        }
+
+        // If no user is found, a null object is returned instead
+        public async Task<Models.UserProfile> GetUserByBotIdAsync(string botId)
+        {
+            using (var context = ServiceProvider.CreateScope())
+            {
+                var db = context.ServiceProvider.GetRequiredService<GretaDBContext>();
+
+                return await db.UserProfile.Where(u => u.BotUserId == botId).FirstOrDefaultAsync();
+            }
+        }
+
+
+        public async Task ValidateUserAsync(int prestashopId, int permission)
+        {
+            using (var context = ServiceProvider.CreateScope())
+            {
+                var db = context.ServiceProvider.GetRequiredService<GretaDBContext>();
+
+                var user = await db.UserProfile.Where(u => u.PrestashopId == prestashopId).FirstOrDefaultAsync();
+
+                user.Validated = true;
+                user.Permission = permission;
+
+                await db.SaveChangesAsync();
+            }
+        }
+    }
+}

--- a/ConversationData.cs
+++ b/ConversationData.cs
@@ -14,5 +14,7 @@ namespace CoreBot
         public NodeDecisio RootNode { get; set; }
 
         public Dictionary<string, DateTime> DisabledCards { get; } = new Dictionary<string,DateTime>();
+
+        public bool Welcomed { get; set; } = false;
     }
 }

--- a/CoreBot.csproj
+++ b/CoreBot.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="1.2.4" />
+    <PackageReference Include="BCrypt.Net-Core" Version="1.6.0" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.6.3" />
     <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.6.3" />

--- a/Dialogs/AddProductInfoDialog.cs
+++ b/Dialogs/AddProductInfoDialog.cs
@@ -1,4 +1,5 @@
 ﻿using AdaptiveCards;
+using CoreBot.Controllers;
 using CoreBot.Utilities;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
@@ -19,8 +20,8 @@ namespace CoreBot.Dialogs
         private const string Preview = "Do you want to preview the Product you just added?";
         private readonly IConfiguration Configuration;
 
-        public AddProductInfoDialog(UserState userState, ConversationState conversationState, IConfiguration configuration) 
-            : base(nameof(AddProductInfoDialog), userState, conversationState)
+        public AddProductInfoDialog(UserController userController, ConversationState conversationState, IConfiguration configuration) 
+            : base(nameof(AddProductInfoDialog), userController, conversationState)
         {
             AddDialog(new TextPrompt(nameof(TextPrompt), ValidateCardInputAsync));
             AddDialog(new ConfirmPrompt(nameof(ConfirmPrompt)));
@@ -36,7 +37,7 @@ namespace CoreBot.Dialogs
             InitialDialogId = nameof(WaterfallDialog);
 
             // VITROSEP and Superusers only
-            PermissionLevel = VITROSEP;
+            PermissionLevel = PermissionLevels.Vitrosep;
             Configuration = configuration;
         }
 

--- a/Dialogs/AskUserInfoDialog.cs
+++ b/Dialogs/AskUserInfoDialog.cs
@@ -1,5 +1,10 @@
-﻿using Microsoft.Bot.Builder;
+﻿using CoreBot.Extensions;
+using CoreBot.Utilities;
+using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Schema;
+using Newtonsoft.Json;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -11,31 +16,99 @@ namespace CoreBot.Dialogs
         private const string askNameMsg = "My name is Greta, who are you?";
         private const string askCompanyMsg = "What company do you work for?";
         private const string finishMsg = "Thank you, what can I do for you today?";
+        private const string registeredMsg = "Are you registered in our web store? (You need to be registered in order to get the most out of me!)";
+        private const string waitForValidationMsg = "Thanks for registering.\nA VITROSEP administrator will validate your user soon, we will send you a notification asap!";
+        private const string unregisteredName = "As a non registered user, you must have a name!\nWhat do you want me to call you?";
 
-        public AskUserInfoDialog(UserState userState) : base(nameof(AskUserInfoDialog))
+        public AskUserInfoDialog(UserState userState, UserLoginDialog userLoginDialog) : base(nameof(AskUserInfoDialog))
         {
             AddDialog(new TextPrompt(nameof(TextPrompt)));
             AddDialog(new ConfirmPrompt(nameof(ConfirmPrompt)));
             AddDialog(new WaterfallDialog(nameof(WaterfallDialog), new WaterfallStep[]
-                {
-                    AskNameAsync,
-                    AskIfCompanyAsync,
-                    AskCompanyAsync,
-                    FinalStepAsync,
-                }));
+            {
+                WelcomeStepAsync,
+                AskForRegistrationStepAsync,
+                RegisterOptionalStepAsync,
+                AskIfCompanyStepAsync,
+                AskCompanyStepAsync,
+                FinalStepAsync,
+            }));
+            AddDialog(userLoginDialog);
 
             _profileAccessor = userState.CreateProperty<UserProfile>(nameof(UserProfile));
             InitialDialogId = nameof(WaterfallDialog);
         }
 
-        private async Task<DialogTurnResult> AskNameAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        private async Task<DialogTurnResult> WelcomeStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
-            await stepContext.Context.SendActivityAsync(MessageFactory.Text("First of all, let's get to know each other."), cancellationToken);
+            var card = CardUtils.CreateCardFromJson("gretaWelcomeCard");
 
-            return await stepContext.PromptAsync(nameof(TextPrompt), new PromptOptions { Prompt = MessageFactory.Text(askNameMsg) }, cancellationToken);
+            var activity = new Activity
+            {
+                Attachments = new List<Attachment>() {
+                    new Attachment()
+                    {
+                        Content = JsonConvert.DeserializeObject(JsonConvert.SerializeObject(card)),
+                        ContentType = "application/vnd.microsoft.card.adaptive"
+                    }
+                },
+                Type = ActivityTypes.Message
+            };
+
+            var promptOptions = new PromptOptions
+            {
+                Prompt = MessageFactory.Text(registeredMsg),
+                RetryPrompt = MessageFactory.Text(registeredMsg + " (Yes/No)")
+            };
+
+            await stepContext.Context.SendActivityAsync(activity);
+            return await stepContext.PromptAsync(nameof(ConfirmPrompt), promptOptions, cancellationToken);
         }
 
-        private async Task<DialogTurnResult> AskIfCompanyAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        private async Task<DialogTurnResult> AskForRegistrationStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        {
+            var result = (bool)stepContext.Result;
+
+            if (result)
+            {
+                await stepContext.Context.SendActivityAsync("Use your VitrosepStore credentials to log in");
+                await stepContext.BeginDialogAsync(nameof(UserLoginDialog), null, cancellationToken);
+                return await stepContext.EndDialogAsync(null, cancellationToken);
+            }
+            else
+            { 
+                var promptOptions = new PromptOptions
+                {
+                    Prompt = MessageFactory.Text("Would you like to register?"),
+                    RetryPrompt = MessageFactory.Text("Would you like to register? (Yes/No)")
+                };
+
+                return await stepContext.PromptAsync(nameof(ConfirmPrompt), promptOptions, cancellationToken);
+            }
+        }
+
+        private async Task<DialogTurnResult> RegisterOptionalStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        {
+            var result = (bool)stepContext.Result;
+            if (result)
+            {
+                System.Diagnostics.Process.Start("https://vitrosepstore.com/en/login?create_account=1");
+
+                await stepContext.Context.SendActivityAsync(waitForValidationMsg);
+                return await stepContext.EndDialogAsync(null, cancellationToken);
+            }
+            else
+            {
+                var promptOptions = new PromptOptions
+                {
+                    Prompt = MessageFactory.Text(unregisteredName)
+                };
+
+                return await stepContext.PromptAsync(nameof(TextPrompt), promptOptions, cancellationToken);
+            }
+        }
+
+        private async Task<DialogTurnResult> AskIfCompanyStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
             var name = (string)stepContext.Result;
 
@@ -50,7 +123,7 @@ namespace CoreBot.Dialogs
             return await stepContext.PromptAsync(nameof(ConfirmPrompt), new PromptOptions { Prompt = message }, cancellationToken);
         }
 
-        private async Task<DialogTurnResult> AskCompanyAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        private async Task<DialogTurnResult> AskCompanyStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
             var userProfile = (UserProfile)stepContext.Values["profile"];
 

--- a/Dialogs/CancelAndHelpDialog.cs
+++ b/Dialogs/CancelAndHelpDialog.cs
@@ -1,35 +1,26 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using CoreBot.Controllers;
 using CoreBot.Permission;
+using CoreBot.Utilities;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Schema;
+using Newtonsoft.Json;
 
 namespace CoreBot.Dialogs
 {
-    public class CancelAndHelpDialog : ComponentDialog, IPermissionObject
+    public class CancelAndHelpDialog : PermissionDialog
     {
-        // Permission levels
-        protected const int SUPERUSER = 0;
-        protected const int VITROSEP = 1;
-        protected const int CUSTOMERS = 2;
-        protected const int REPRESENTATIVE = 3;
-        protected const int LEAD = 4;
-        protected const int UNREGISTERED = 5;
-        protected static readonly string[] permissions = { "Superuser", "Vitrosep", "Customer", "Representative", "Lead", "Unregistered"};
-
         protected const string whatElse = "What else can I do for you today?";
-        private const string noPermission = "Sorry, you don't have privilege to use this functionality.";
-        protected readonly IStatePropertyAccessor<UserProfile> _profileAccessor;
-        public int PermissionLevel { get; set; } = 5;
 
-        public CancelAndHelpDialog(string id, UserState userState)
-            : base(id)
+        public CancelAndHelpDialog(string id, UserController userController)
+            : base(userController,id)
         {
-            _profileAccessor = userState.CreateProperty<UserProfile>(nameof(UserProfile));
         }
 
         protected override async Task<DialogTurnResult> OnBeginDialogAsync(DialogContext innerDc, object options, CancellationToken cancellationToken = default(CancellationToken))
@@ -64,7 +55,8 @@ namespace CoreBot.Dialogs
                 {
                     case "help":
                     case "?":
-                        await innerDc.Context.SendActivityAsync($"Show Help...", cancellationToken: cancellationToken);
+                        var dialog = innerDc.Stack[innerDc.Stack.Count - 1];
+                        await innerDc.Context.SendActivityAsync($"{dialog.State["stepIndex"]}", cancellationToken: cancellationToken);
                         return new DialogTurnResult(DialogTurnStatus.Waiting);
 
                     case "cancel":
@@ -77,37 +69,24 @@ namespace CoreBot.Dialogs
             return null;
         }
 
-        protected async Task<DialogTurnResult> CheckPermissionStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
-        {
-            var userProfile = await _profileAccessor.GetAsync(stepContext.Context, () => new UserProfile());
-            if (HasPermission(userProfile.Permission))
-            {
-                return await stepContext.NextAsync(stepContext.Options, cancellationToken);
-            }
-            else
-            {
-                await stepContext.Context.SendActivityAsync(MessageFactory.Text(noPermission),cancellationToken);
-                return await stepContext.EndDialogAsync(null, cancellationToken);
-            }
-        }
 
-        protected int ResolvePermission(string permission)
+        protected virtual async Task ShowHelpAsync(DialogContext innerDc)
         {
-            switch (permission)
-            {
-                case "Superuser": return SUPERUSER;
-                case "Vitrosep": return VITROSEP;
-                case "Customer": return CUSTOMERS;
-                case "Representative": return REPRESENTATIVE;
-                case "Lead": return LEAD;
-                case "Unregistered": return UNREGISTERED;
-                default: return -1;
-            }
-        }
+            var card = CardUtils.CreateCardFromJson("gretaWelcomeCard");
 
-        public bool HasPermission(int permission)
-        {
-            return PermissionLevel >= permission;
+            var activity = new Microsoft.Bot.Schema.Activity
+            {
+                Attachments = new List<Attachment>() {
+                    new Attachment()
+                    {
+                        Content = JsonConvert.DeserializeObject(JsonConvert.SerializeObject(card)),
+                        ContentType = "application/vnd.microsoft.card.adaptive"
+                    }
+                },
+                Type = ActivityTypes.Message
+            };
+
+            await innerDc.Context.SendActivityAsync(activity);
         }
     }
 }

--- a/Dialogs/CancelAndHelpDialog.cs
+++ b/Dialogs/CancelAndHelpDialog.cs
@@ -17,6 +17,7 @@ namespace CoreBot.Dialogs
     public class CancelAndHelpDialog : PermissionDialog
     {
         protected const string whatElse = "What else can I do for you today?";
+        protected const string WATERFALL = "WaterfallDialog";
 
         public CancelAndHelpDialog(string id, UserController userController)
             : base(userController,id)
@@ -55,8 +56,7 @@ namespace CoreBot.Dialogs
                 {
                     case "help":
                     case "?":
-                        var dialog = innerDc.Stack[innerDc.Stack.Count - 1];
-                        await innerDc.Context.SendActivityAsync($"{dialog.State["stepIndex"]}", cancellationToken: cancellationToken);
+                        await ShowHelpAsync(innerDc);
                         return new DialogTurnResult(DialogTurnStatus.Waiting);
 
                     case "cancel":
@@ -74,7 +74,7 @@ namespace CoreBot.Dialogs
         {
             var card = CardUtils.CreateCardFromJson("gretaWelcomeCard");
 
-            var activity = new Microsoft.Bot.Schema.Activity
+            var activity = new Activity
             {
                 Attachments = new List<Attachment>() {
                     new Attachment()

--- a/Dialogs/CardDialog.cs
+++ b/Dialogs/CardDialog.cs
@@ -1,4 +1,5 @@
-﻿using CoreBot.Utilities;
+﻿using CoreBot.Controllers;
+using CoreBot.Utilities;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Newtonsoft.Json.Linq;
@@ -11,7 +12,9 @@ namespace CoreBot.Dialogs
     public class CardDialog : CancelAndHelpDialog
     {
         private readonly IStatePropertyAccessor<ConversationData> _conversationAccessor;
-        public CardDialog(string id, UserState userState, ConversationState conversationState) : base(id, userState)
+ 
+        public CardDialog(string id, UserController userController, ConversationState conversationState)
+            : base(id,userController)
         {
             _conversationAccessor = conversationState.CreateProperty<ConversationData>(nameof(ConversationData));
         }

--- a/Dialogs/ConfirmOrderDialog.cs
+++ b/Dialogs/ConfirmOrderDialog.cs
@@ -1,4 +1,5 @@
-﻿using CoreBot.Utilities;
+﻿using CoreBot.Controllers;
+using CoreBot.Utilities;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Schema;
@@ -14,10 +15,10 @@ namespace CoreBot.Dialogs
         private const string noOrderMsg = "Sorry, you need to order something first.";
         private const string ignoreOrder = "Your order is still pending, you can confirm, cancel or add more products!";
 
-        public ConfirmOrderDialog(UserState userState, ConversationState conversationState) 
-            : base(nameof(ConfirmOrderDialog),userState, conversationState)
+        public ConfirmOrderDialog(UserController userController, ConversationState conversationState) 
+            : base(nameof(ConfirmOrderDialog),userController, conversationState)
         {
-            AddDialog(new TextPrompt(nameof(TextPrompt)));
+            /*AddDialog(new TextPrompt(nameof(TextPrompt)));
             AddDialog(new ConfirmPrompt(nameof(ConfirmPrompt)));
             AddDialog(new WaterfallDialog(nameof(WaterfallDialog), new WaterfallStep[]
             {
@@ -27,13 +28,13 @@ namespace CoreBot.Dialogs
                 DisableCardStepAsync,
                 ProcessValueStepAsync,
                 FinalStepAsync
-            }));
+            }));*/
 
-            PermissionLevel = REPRESENTATIVE;
+            PermissionLevel = PermissionLevels.Representative;
             InitialDialogId = nameof(WaterfallDialog);
         }
 
-        private async Task<DialogTurnResult> CheckOrderStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        /*private async Task<DialogTurnResult> CheckOrderStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
             var userProfile = await _profileAccessor.GetAsync(stepContext.Context, () => new UserProfile());
 
@@ -107,6 +108,6 @@ namespace CoreBot.Dialogs
             await stepContext.Context.SendActivityAsync(MessageFactory.Text(whatElse), cancellationToken);
 
             return await stepContext.EndDialogAsync(null, cancellationToken);
-        }
+        }*/
     }
 }

--- a/Dialogs/MainDialog.cs
+++ b/Dialogs/MainDialog.cs
@@ -85,7 +85,7 @@ namespace CoreBot.Dialogs
 
         private async Task<DialogTurnResult> DispatchStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
-            var intent = stepContext.Values["Intent"];
+            var intent = stepContext.GetValue<string>("Intent");
             var recognizer = stepContext.Result as RecognizerResult ?? null;
 
             switch (intent)

--- a/Dialogs/MainDialog.cs
+++ b/Dialogs/MainDialog.cs
@@ -1,4 +1,5 @@
-﻿using CoreBot.Extensions;
+﻿using CoreBot.Controllers;
+using CoreBot.Extensions;
 using CoreBot.Store;
 using CoreBot.Utilities;
 using Microsoft.Azure.CognitiveServices.Language.LUIS.Runtime.Models;
@@ -8,6 +9,7 @@ using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Configuration;
 using System.Collections.Generic;
 using System.Data.SqlClient;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,13 +19,16 @@ namespace CoreBot.Dialogs
     public class MainDialog : ComponentDialog
     {
         protected IBotServices BotServices;
-        private readonly IStatePropertyAccessor<UserProfile> _profileAccessor;
+        private readonly IStatePropertyAccessor<ConversationData> _conversationAccessor;
         private readonly IConfiguration Configuration;
+        private readonly UserController UserController;
+        private readonly NotifyController NotifyController;
         private readonly IPrestashopApi PrestashopApi;
 
         public MainDialog(IBotServices botServices, TechnicalAssistanceDialog technicalAssistance,
-            OrderProductDialog orderProduct, AskUserInfoDialog infoDialog, UserState userState, ConfirmOrderDialog confirmOrderDialog,
-            AddProductInfoDialog addProductInfoDialog, UserValidationDialog userValidationDialog, IConfiguration configuration)
+            OrderProductDialog orderProduct, AskUserInfoDialog infoDialog, ConversationState conversationState, ConfirmOrderDialog confirmOrderDialog,
+            AddProductInfoDialog addProductInfoDialog, UserValidationDialog userValidationDialog, IConfiguration configuration,
+            UserController userController, NotifyController notifyController, IPrestashopApi prestashopApi)
             : base(nameof(MainDialog))
         {
             AddDialog(new TextPrompt(nameof(TextPrompt)));
@@ -38,22 +43,28 @@ namespace CoreBot.Dialogs
                 WelcomeStepAsync,
                 InitialStepAsync,
                 DispatchStepAsync,
-                //FinalStepAsync,
+                FinalStepAsync,
             }));
 
             InitialDialogId = nameof(WaterfallDialog);
             BotServices = botServices;
-            _profileAccessor = userState.CreateProperty<UserProfile>(nameof(UserProfile));
+            UserController = userController;
+            NotifyController = notifyController;
+            PrestashopApi = prestashopApi;
+            _conversationAccessor = conversationState.CreateProperty<ConversationData>(nameof(ConversationData));
             Configuration = configuration;
         }
 
         private async Task<DialogTurnResult> WelcomeStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
-            var userProfile = await _profileAccessor.GetAsync(stepContext.Context, () => new UserProfile());
+            var conversationData = await _conversationAccessor.GetAsync(
+                stepContext.Context, () => new ConversationData()
+            );
 
-            if (!userProfile.AskedForUserInfo)
+            if (!conversationData.Welcomed)
             {
-                return await stepContext.BeginDialogAsync(nameof(AskUserInfoDialog), null, cancellationToken);
+                conversationData.Welcomed = true;
+                return await stepContext.ReplaceDialogAsync(nameof(AskUserInfoDialog), null, cancellationToken);
             }
 
             return await stepContext.NextAsync(null,cancellationToken);
@@ -91,6 +102,8 @@ namespace CoreBot.Dialogs
             switch (intent)
             {
                 case "ProductInformation":
+                    // TODO (ARREGLAR-HO)
+
                     var luisResult = (LuisResult)recognizer.Properties["luisResult"];
                     // Invoquem el mètode d'extensió que hem creat
                     var productInfo = luisResult.ToProductInfo(Configuration);
@@ -126,8 +139,37 @@ namespace CoreBot.Dialogs
                     return await stepContext.BeginDialogAsync(nameof(AddProductInfoDialog), cancellationToken);
 
                 case "CheckProducts":
-                    string products = await GetProductNamesAsync(stepContext.Context);
-                    await stepContext.Context.SendActivityAsync(MessageFactory.Text(products), cancellationToken);
+                    var task = DisplayAllProductsAsync(stepContext,cancellationToken);
+
+                    await stepContext.Context.SendActivityAsync("Wait till I load them all...");
+
+                    await task;
+                    break;
+
+                case "Register":
+                    var ps = new ProcessStartInfo("https://vitrosepstore.com/en/login?create_account=1")
+                    {
+                        UseShellExecute = true,
+                        Verb = "open"
+                    };
+                    Process.Start(ps);
+                    break;
+
+                case "AskValidation":
+                    var botId = stepContext.Context.Activity.From.Id;
+                    var user = await UserController.GetUserByBotIdAsync(botId);
+
+                    if(user != null && user.PrestashopId != null)
+                    {
+                        await NotifyController.RequestValidationAsync(botId);
+                        await stepContext.Context.SendActivityAsync("I sent a validation request to a member of our staff");
+                    }
+                    else
+                    {
+                        await stepContext.Context.SendActivityAsync("You're not logged in! In order to ask for validation " +
+                            "you have to log in first (just ask me *I want to log in*), and if you're not registered yet " +
+                            "ask me to register (*I want to register*) and then log in.\n You can request the validation right after :)");
+                    }
                     break;
 
                 case "ValidateUser":
@@ -139,44 +181,32 @@ namespace CoreBot.Dialogs
                     break;
             }
 
+            return await stepContext.NextAsync(null, cancellationToken);
+        }
+
+
+
+        private async Task<DialogTurnResult> FinalStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        {
+            await stepContext.Context.SendActivityAsync("What else can I do for you today?");
             return await stepContext.EndDialogAsync(null, cancellationToken);
         }
 
 
-        private async Task<string> GetProductNamesAsync(ITurnContext turnContext)
+        private async Task DisplayAllProductsAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
-            var userProfile = await _profileAccessor.GetAsync(turnContext, () => new UserProfile());
+            var products = await PrestashopApi.GetAllProducts();
 
-            if (userProfile.Permission > 1)
-            {
-                return "Sorry, you don't have permission to use this feature.";
-            }
-            else
-            {
-                string connectionString = Configuration.GetConnectionString("DefaultConnection");
-                string query = "SELECT ProductName FROM [dbo].[ProductInfo]";
+            var reply = stepContext.Context.Activity.CreateReply();
+            reply.AttachmentLayout = AttachmentLayoutTypes.Carousel;
+            reply.Attachments = products.ToCarousel(Configuration);
 
-                using (SqlConnection connection = new SqlConnection(connectionString))
-                {
-                    SqlCommand command = new SqlCommand(query, connection);
+            await stepContext.Context.SendActivityAsync(reply, cancellationToken);
+        }
 
-                    connection.Open();
-                    SqlDataReader reader = command.ExecuteReader();
-
-                    string products = "This is the list of products in the DataBase:\n";
-
-                    while (reader.Read())
-                    {
-                        products += $"- {reader.GetString(0)}\n";
-                    }
-
-                    command.Dispose();
-                    reader.Close();
-                    connection.Close();
-
-                    return products;
-                }
-            }
+        private async Task DisplayProductInfoAsync(LuisResult luisResult)
+        {
+            //TODO
         }
     }
 }

--- a/Dialogs/OrderProductDialog.cs
+++ b/Dialogs/OrderProductDialog.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using CoreBot.Controllers;
 using CoreBot.Store;
 using CoreBot.Utilities;
 using Microsoft.Bot.Builder;
@@ -22,8 +23,8 @@ namespace CoreBot.Dialogs
         private readonly IPrestashopApi PrestashopApi;
         private readonly IConfiguration Configuration;
 
-        public OrderProductDialog(UserState userState, ConversationState conversationState, IPrestashopApi prestashopApi, IConfiguration configuration) 
-            : base(nameof(OrderProductDialog),userState,conversationState)
+        public OrderProductDialog(UserController userController, ConversationState conversationState, IPrestashopApi prestashopApi, IConfiguration configuration) 
+            : base(nameof(OrderProductDialog),userController,conversationState)
         {
             AddDialog(new TextPrompt(nameof(TextPrompt)));
             AddDialog(new TextPrompt("TextValidator", ValidateQuantityAsync));
@@ -41,7 +42,7 @@ namespace CoreBot.Dialogs
                }));
 
             InitialDialogId = nameof(WaterfallDialog);
-            PermissionLevel = UNREGISTERED;
+            PermissionLevel = PermissionLevels.Representative;
             PrestashopApi = prestashopApi;
             Configuration = configuration;
         }
@@ -126,9 +127,9 @@ namespace CoreBot.Dialogs
 
         private async Task<DialogTurnResult> AddToCartStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
-            //TO_DO Add Order to Prestashop
+            //TODO Add Order to Prestashop (esperar GSP)
 
-            var singleOrder = (SingleOrder)stepContext.Options;
+            /*var singleOrder = (SingleOrder)stepContext.Options;
 
             if ((bool)stepContext.Result)
             {
@@ -148,7 +149,7 @@ namespace CoreBot.Dialogs
             else
             {
                 await stepContext.Context.SendActivityAsync(MessageFactory.Text(notAddedMsg), cancellationToken);
-            }
+            }*/
 
             await stepContext.Context.SendActivityAsync(MessageFactory.Text(whatElse), cancellationToken);
 
@@ -159,7 +160,7 @@ namespace CoreBot.Dialogs
         {
             var product = promptContext.Context.Activity.Text;
             var collection = await PrestashopApi.GetProductByName(product);
-            return await Task.FromResult(collection.Products.Length == 0);
+            return await Task.FromResult(collection.Products.Count == 0);
         }
 
         private Task<bool> ValidateQuantityAsync(PromptValidatorContext<string> promptContext, CancellationToken cancellationToken)

--- a/Dialogs/PermissionDialog.cs
+++ b/Dialogs/PermissionDialog.cs
@@ -3,6 +3,7 @@ using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,14 +12,6 @@ namespace CoreBot.Dialogs
 {
     public class PermissionDialog : ComponentDialog
     {
-        // Permission levels
-        protected const int SUPERUSER = 0;
-        protected const int VITROSEP = 1;
-        protected const int CUSTOMERS = 2;
-        protected const int REPRESENTATIVE = 3;
-        protected const int LEAD = 4;
-        protected const int UNREGISTERED = 5;
-        protected static readonly string[] permissions = { "Superuser", "Vitrosep", "Customer", "Representative", "Lead", "Unregistered" };
         private const string noPermission = "Sorry, you don't have privilege to use this functionality.";
 
         protected readonly UserController UserController;
@@ -31,7 +24,7 @@ namespace CoreBot.Dialogs
         protected async Task<DialogTurnResult> CheckPermissionStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
             var user = await UserController.GetUserByBotIdAsync(stepContext.Context.Activity.From.Id);
-            if (user.Permission >= PermissionLevel)
+            if (user.Permission >= (int)PermissionLevel)
             {
                 return await stepContext.NextAsync(stepContext.Options, cancellationToken);
             }
@@ -42,20 +35,22 @@ namespace CoreBot.Dialogs
             }
         }
 
-        public int PermissionLevel { get; set; } = 5;
+        public PermissionLevels PermissionLevel { get; set; } = PermissionLevels.Superuser;
+    }
 
-        protected int ResolvePermission(string permission)
-        {
-            switch (permission)
-            {
-                case "Superuser": return SUPERUSER;
-                case "Vitrosep": return VITROSEP;
-                case "Customer": return CUSTOMERS;
-                case "Representative": return REPRESENTATIVE;
-                case "Lead": return LEAD;
-                case "Unregistered": return UNREGISTERED;
-                default: return -1;
-            }
-        }
+    public enum PermissionLevels : int
+    {
+        [Description("Superuser")]
+        Superuser = 0,
+        [Description("Vitrosep")]
+        Vitrosep = 1,
+        [Description("Customer")]
+        Customer = 2,
+        [Description("Representative")]
+        Representative = 3,
+        [Description("Lead")]
+        Lead = 4,
+        [Description("Unregistered")]
+        Unregistered = 5
     }
 }

--- a/Dialogs/PermissionDialog.cs
+++ b/Dialogs/PermissionDialog.cs
@@ -1,0 +1,61 @@
+﻿using CoreBot.Controllers;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CoreBot.Dialogs
+{
+    public class PermissionDialog : ComponentDialog
+    {
+        // Permission levels
+        protected const int SUPERUSER = 0;
+        protected const int VITROSEP = 1;
+        protected const int CUSTOMERS = 2;
+        protected const int REPRESENTATIVE = 3;
+        protected const int LEAD = 4;
+        protected const int UNREGISTERED = 5;
+        protected static readonly string[] permissions = { "Superuser", "Vitrosep", "Customer", "Representative", "Lead", "Unregistered" };
+        private const string noPermission = "Sorry, you don't have privilege to use this functionality.";
+
+        protected readonly UserController UserController;
+        
+        public PermissionDialog(UserController userController, string id) : base(id)
+        {
+            UserController = userController;
+        }
+
+        protected async Task<DialogTurnResult> CheckPermissionStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        {
+            var user = await UserController.GetUserByBotIdAsync(stepContext.Context.Activity.From.Id);
+            if (user.Permission >= PermissionLevel)
+            {
+                return await stepContext.NextAsync(stepContext.Options, cancellationToken);
+            }
+            else
+            {
+                await stepContext.Context.SendActivityAsync(MessageFactory.Text(noPermission), cancellationToken);
+                return await stepContext.EndDialogAsync(null, cancellationToken);
+            }
+        }
+
+        public int PermissionLevel { get; set; } = 5;
+
+        protected int ResolvePermission(string permission)
+        {
+            switch (permission)
+            {
+                case "Superuser": return SUPERUSER;
+                case "Vitrosep": return VITROSEP;
+                case "Customer": return CUSTOMERS;
+                case "Representative": return REPRESENTATIVE;
+                case "Lead": return LEAD;
+                case "Unregistered": return UNREGISTERED;
+                default: return -1;
+            }
+        }
+    }
+}

--- a/Dialogs/UserLoginDialog.cs
+++ b/Dialogs/UserLoginDialog.cs
@@ -1,0 +1,205 @@
+﻿using CoreBot.Extensions;
+using CoreBot.Models;
+using CoreBot.Store;
+using CoreBot.Utilities;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Schema;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CoreBot.Dialogs
+{
+    public class UserLoginDialog : CardDialog
+    {
+        private readonly IPrestashopApi PrestashopApi;
+        private readonly IConfiguration Configuration;
+        private readonly IServiceProvider ServiceProvider;
+        private string UserEmail;
+
+        public UserLoginDialog(UserState userState, ConversationState conversationState, IPrestashopApi prestashopApi, IConfiguration configuration,
+            IServiceProvider serviceProvider) : base(nameof(UserLoginDialog), userState, conversationState)
+        {
+            AddDialog(new TextPrompt("EmailValidator", ValidateEmailAsync));
+            AddDialog(new TextPrompt("PasswordValidator", ValidatePasswordAsync));
+            AddDialog(new TextPrompt(nameof(TextPrompt)));
+            AddDialog(new ConfirmPrompt(nameof(ConfirmPrompt)));
+            AddDialog(new WaterfallDialog(nameof(WaterfallDialog), new WaterfallStep[]
+            {
+                CheckPermissionStepAsync,
+                AskEmailStepAsync,
+                ConfirmPasswordStepAsync,
+                DisableCardStepAsync,
+                CheckUserProfileStepAsync,
+                AskForVerificationStepAsync,
+                FinalStepAsync
+            }));
+
+            PrestashopApi = prestashopApi;
+            Configuration = configuration;
+            ServiceProvider = serviceProvider;
+            PermissionLevel = UNREGISTERED;
+            InitialDialogId = nameof(WaterfallDialog);
+        }
+
+        private async Task<DialogTurnResult> AskEmailStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        {
+            var promptOptions = new PromptOptions
+            {
+                Prompt = MessageFactory.Text("Please enter your username (email)"),
+                RetryPrompt = MessageFactory.Text("This email does not exist. Please try again. You can cancel anytime.")
+            };
+
+            return await stepContext.PromptAsync("EmailValidator", promptOptions, cancellationToken);
+        }
+
+        private async Task<DialogTurnResult> ConfirmPasswordStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        {
+            UserEmail = (string)stepContext.Result;
+            var customer = (await PrestashopApi.GetCustomerByEmail(UserEmail)).First();
+            var card = CardUtils.CreateCardFromJson("submitPassword");
+
+            var activity = new Activity
+            {
+                Attachments = new List<Attachment>() { 
+                    new Attachment()
+                    {
+                        Content = JsonConvert.DeserializeObject(JsonConvert.SerializeObject(card)),
+                        ContentType = "application/vnd.microsoft.card.adaptive"
+                    }
+                },
+                Type = ActivityTypes.Message
+            };
+
+            var promptOptions = new PromptOptions
+            {
+                Prompt = activity,
+                RetryPrompt = activity
+            };
+
+            await stepContext.Context.SendActivityAsync($"Hi, in order to verify you're {customer.FirstName + " " + customer.LastName}, please enter your password",
+                null,InputHints.IgnoringInput, cancellationToken);
+
+            return await stepContext.PromptAsync("PasswordValidator", promptOptions, cancellationToken);
+        }
+
+        private async Task<DialogTurnResult> CheckUserProfileStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        {
+            // The user passed the email validation so we can assume the user exists. 
+            var customer = (await PrestashopApi.GetCustomerByEmail(UserEmail)).First();
+
+            if (await CheckForUserProfileAsync(customer.Id))
+            {
+                stepContext.Values["verificationStep"] = false;
+                return await stepContext.NextAsync(null, cancellationToken);
+            }
+            else
+            {
+                stepContext.Values["verificationStep"] = true;
+
+                var promptOptions = new PromptOptions
+                {
+                    Prompt = MessageFactory.Text("Your profile is not validated yet, would you like to ask for validation?"),
+                    RetryPrompt = MessageFactory.Text("Your profile is not validated yet, would you like to ask for validation? (Yes/No)")
+                };
+
+                return await stepContext.PromptAsync(nameof(ConfirmPrompt), promptOptions, cancellationToken);
+            }
+        }
+
+        private async Task<DialogTurnResult> AskForVerificationStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        {
+            var verification = stepContext.GetValue<bool>("verificationStep");
+
+            if (verification)
+            {
+                // Get the result of the user's choice
+                var result = (bool)stepContext.Result;
+
+                if (result)
+                {
+                    await stepContext.Context.SendActivityAsync("TO_DO Send notification for user Validation");
+                    return await stepContext.EndDialogAsync(true, cancellationToken);
+                }
+                else
+                {
+                    return await stepContext.EndDialogAsync(false, cancellationToken);
+                }
+            }
+            else
+            {
+                return await stepContext.NextAsync(null, cancellationToken);
+            }
+        }
+
+
+        private async Task<DialogTurnResult> FinalStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        {
+            await stepContext.Context.SendActivityAsync("Login Successful");
+
+            return await stepContext.EndDialogAsync(true, cancellationToken);
+        }
+
+        private async Task<bool> ValidateEmailAsync(PromptValidatorContext<string> promptContext, CancellationToken cancellationToken)
+        {
+            var email = promptContext.Context.Activity.Text;
+
+            var userCollection = await PrestashopApi.GetCustomerByEmail(email);
+
+            if(userCollection.Elements.Count == 0)
+            {
+                //await promptContext.Context.SendActivityAsync(MessageFactory.Text("This email does not exist"));
+                return await Task.FromResult(false);
+            }
+
+            return await Task.FromResult(true);
+        }
+
+        private async Task<bool> ValidatePasswordAsync(PromptValidatorContext<string> promptContext, CancellationToken cancellationToken)
+        {
+            var customer = (await PrestashopApi.GetCustomerByEmail(UserEmail)).First();
+
+            string json = promptContext.Context.Activity.Text;
+            var password = CardUtils.GetValueFromAction<string>(json);
+
+            //BCrypt algorythm for newer generated passwords
+            if (customer.Password.Length == 60)
+            {
+                return await Task.FromResult(BCrypt.Net.BCrypt.Verify(password, customer.Password));
+            }
+            //MD5 hashing for older generated passwords
+            else
+            {
+                var provider = MD5.Create();
+                string salt = Configuration.GetSection("PrestashopSettings").GetSection("CookieKey").Value;
+                byte[] bytes = provider.ComputeHash(Encoding.ASCII.GetBytes(salt + password));
+                string computedHash = BitConverter.ToString(bytes);
+
+                return await Task.FromResult(computedHash == customer.Password);
+            }
+        }
+
+        private async Task<bool> CheckForUserProfileAsync(int userId)
+        {
+            using (var scope = ServiceProvider.CreateScope())
+            {
+                var db = scope.ServiceProvider.GetRequiredService<GretaDBContext>();
+
+                var sources = await db.UserProfile
+                    .Where(x => x.Id == userId)
+                    .SingleOrDefaultAsync();
+
+                return await Task.FromResult(sources != null);
+            }
+        }
+    }
+}

--- a/Extensions/PermissionExtensions.cs
+++ b/Extensions/PermissionExtensions.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace CoreBot.Extensions
+{
+    public static class PermissionExtensions
+    {
+        public static string GetDescription(this Enum value)
+        {
+            FieldInfo field = value.GetType().GetField(value.ToString());
+
+            return !(Attribute.GetCustomAttribute(field, typeof(DescriptionAttribute)) 
+                is DescriptionAttribute attribute) ? value.ToString() : attribute.Description;
+        }
+
+        public static T GetValueFromDescription<T>(this string description)
+        {
+            var type = typeof(T);
+            if (!type.IsEnum) throw new InvalidOperationException();
+
+            foreach (var field in type.GetFields())
+            {
+                if (Attribute.GetCustomAttribute(field,
+                    typeof(DescriptionAttribute)) is DescriptionAttribute attribute)
+                {
+                    if (attribute.Description == description)
+                        return (T)field.GetValue(null);
+                }
+                else
+                {
+                    if (field.Name == description)
+                        return (T)field.GetValue(null);
+                }
+            }
+            throw new ArgumentException("Not found.", nameof(description));
+            // or return default(T);
+        }
+    }
+}

--- a/Models/GretaDBContext.cs
+++ b/Models/GretaDBContext.cs
@@ -24,7 +24,7 @@ namespace CoreBot.Models
         {
             modelBuilder.Entity<Naquestions>(entity =>
             {
-                entity.HasKey(e => e.QuestionId);
+                entity.HasKey(e => e.Id);
 
                 entity.ToTable("NAQuestions");
 
@@ -38,6 +38,8 @@ namespace CoreBot.Models
                     .HasForeignKey(d => d.UserId)
                     .OnDelete(DeleteBehavior.ClientSetNull)
                     .HasConstraintName("FK_NAQuestions_UserProfile");
+
+                entity.Property(e => e.Id).ValueGeneratedOnAdd();
             });
 
             modelBuilder.Entity<OrderLine>(entity =>

--- a/Models/Naquestions.cs
+++ b/Models/Naquestions.cs
@@ -5,10 +5,17 @@ namespace CoreBot.Models
 {
     public partial class Naquestions
     {
-        public int QuestionId { get; set; }
+        public int Id { get; set; }
         public string QuestionText { get; set; }
         public int UserId { get; set; }
+        public DateTime CreationDate { get; set; }
+
 
         public UserProfile User { get; set; }
+
+        public Naquestions()
+        {
+            CreationDate = DateTime.Now;
+        }
     }
 }

--- a/Models/UserProfile.cs
+++ b/Models/UserProfile.cs
@@ -19,8 +19,9 @@ namespace CoreBot.Models
         }
 
         public int Id { get; set; }
+        public string BotUserId { get; set; }
         public int? PrestashopId { get; set; }
-        public bool Welcomed { get; set; }
+        public bool Validated { get; set; }
         public int Permission { get; set; }
         public DateTime CreationDate { get; set; }
 

--- a/Startup.cs
+++ b/Startup.cs
@@ -63,6 +63,8 @@ namespace Microsoft.BotBuilderSamples
 
             services.AddSingleton<UserValidationDialog>();
 
+            services.AddSingleton<UserLoginDialog>();
+
             // The Dialog that will be run by the bot.
             services.AddSingleton<MainDialog>();
 

--- a/Startup.cs
+++ b/Startup.cs
@@ -17,6 +17,9 @@ using System;
 using System.Net.Http.Headers;
 using Microsoft.EntityFrameworkCore;
 using CoreBot.Models;
+using System.Collections.Concurrent;
+using Microsoft.Bot.Schema;
+using CoreBot.Controllers;
 
 namespace Microsoft.BotBuilderSamples
 {
@@ -68,8 +71,18 @@ namespace Microsoft.BotBuilderSamples
             // The Dialog that will be run by the bot.
             services.AddSingleton<MainDialog>();
 
+            services.AddSingleton<NotifyController>();
+
+            services.AddSingleton<UserController>();
+
+            services.AddSingleton<QuestionController>();
+
+            services.AddSingleton<PermissionDialog>();
+
             // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.
             services.AddTransient<IBot, GretaBot<MainDialog>>();
+
+            services.AddSingleton<ConcurrentDictionary<string, ConversationReference>>();
 
             var apiKey = Configuration.GetSection("PrestashopSettings").GetSection("ApiKey").Value;
             var storeUrl = Configuration.GetSection("PrestashopSettings").GetSection("StoreUrl").Value;
@@ -82,8 +95,8 @@ namespace Microsoft.BotBuilderSamples
                 {
                     ContentSerializer = new XmlContentSerializer()
                 })
-                .ConfigureHttpClient((c) => c.BaseAddress = new Uri(storeUrl))
-                .ConfigureHttpClient((c) => c.DefaultRequestHeaders.Add("Authorization", "Basic " + encoded));
+                .ConfigureHttpClient(c => c.BaseAddress = new Uri(storeUrl))
+                .ConfigureHttpClient(c => c.DefaultRequestHeaders.Add("Authorization", "Basic " + encoded));
 
             services.AddDbContext<GretaDBContext>(options =>
                 options.UseSqlServer(Configuration.GetConnectionString("DefaultConnection")));

--- a/Store/Carouselable.cs
+++ b/Store/Carouselable.cs
@@ -13,17 +13,14 @@ namespace CoreBot.Store
     public class Carouselable<T> where T : IAttachable
     {
         [XmlIgnore]
-        public T[] Elements { get; set; }
+        public List<T> Elements { get; set; }
 
         public Attachment[] ToCarousel()
         {
-            int i = 0;
             List<Attachment> attachments = new List<Attachment>();
 
-            while (i < Elements.Length)
-            {
-                attachments.Add(Elements[i].ToAttachment());
-                i++;
+            foreach(T element in Elements){
+                attachments.Add(element.ToAttachment());
             }
 
             return attachments.ToArray();
@@ -31,17 +28,16 @@ namespace CoreBot.Store
 
         public Attachment[] ToSelectionCarousel()
         {
-            int i = 0;
             List<Attachment> attachments = new List<Attachment>();
             Guid guid = Guid.NewGuid();
 
-            while (i < Elements.Length)
+            foreach(T element in Elements)
             {
-                var card = Elements[i].ToAdaptiveCard();
+                var card = element.ToAdaptiveCard();
                 card.Actions.Add(new AdaptiveSubmitAction
                 {
                     Title = "SELECT",
-                    DataJson = $@"{{ ""id"" : ""{guid.ToString()}"", ""action"" : ""{Elements[i].Id}""}}"
+                    DataJson = $@"{{ ""id"" : ""{guid.ToString()}"", ""action"" : ""{element.Id}""}}"
                 });
 
                 var attachment = new Attachment
@@ -51,7 +47,6 @@ namespace CoreBot.Store
                 };
 
                 attachments.Add(attachment);
-                i++;
             }
 
             return attachments.ToArray();
@@ -59,7 +54,7 @@ namespace CoreBot.Store
 
         public T First()
         {
-            return Elements.Length > 0 ? Elements[0] : null;
+            return Elements.Count > 0 ? Elements[0] : throw new NullReferenceException("This collection is empty");
         }
     }
 }

--- a/Store/Entity/Customer.cs
+++ b/Store/Entity/Customer.cs
@@ -1,10 +1,11 @@
 ﻿using AdaptiveCards;
 using System;
+using System.Collections.Generic;
 using System.Xml.Serialization;
 
 namespace CoreBot.Store.Entity
 {
-    public class Customer : IAttachable
+    public class Customer : IAttachable, IEquatable<Customer>
     {
         [XmlElement("id")]
         public override int Id { get; set; }
@@ -35,6 +36,11 @@ namespace CoreBot.Store.Entity
         {
             get { return UpdateDate.ToString("yyyy-MM-dd HH:mm:ss"); }
             set { UpdateDate = DateTime.Parse(value); }
+        }
+
+        public bool Equals(Customer other)
+        {
+            return Id == other.Id;
         }
 
         public override AdaptiveCard ToAdaptiveCard()
@@ -68,7 +74,7 @@ namespace CoreBot.Store.Entity
     {
         [XmlArray("customers")]
         [XmlArrayItem("customer", typeof(Customer))]
-        public Customer[] Customers 
+        public List<Customer> Customers 
         {
             get { return Elements; }
             set { Elements = value; }

--- a/Store/Entity/Customer.cs
+++ b/Store/Entity/Customer.cs
@@ -58,6 +58,11 @@ namespace CoreBot.Store.Entity
 
             return card;
         }
+
+        public string GetFullName()
+        {
+            return FirstName + " " + LastName;
+        }
     }
 
     public class CustomerLanguage

--- a/Store/Entity/Product.cs
+++ b/Store/Entity/Product.cs
@@ -92,7 +92,7 @@ namespace CoreBot.Store.Entity
     {
         [XmlArray("products")]
         [XmlArrayItem("product", typeof(Product))]
-        public Product[] Products 
+        public List<Product> Products 
         {
             get { return Elements; }
             set { Elements = value; }

--- a/Store/Entity/Product.cs
+++ b/Store/Entity/Product.cs
@@ -34,7 +34,7 @@ namespace CoreBot.Store.Entity
             foreach(LanguageTraduction l in Name)
             {
                 if (l.Id == language) return l.Text;
-            }
+            }   
 
             return "";
         }
@@ -52,12 +52,17 @@ namespace CoreBot.Store.Entity
         public override AdaptiveCard ToAdaptiveCard()
         {
             var card = new AdaptiveCard("1.0");
-            card.Body.Add(new AdaptiveTextBlock()
+            card.Body.Add(new AdaptiveTextBlock
             {
                 Text = GetNameByLanguage(CardUtils.ENGLISH),
-                Weight = AdaptiveTextWeight.Bolder
+                Weight = AdaptiveTextWeight.Bolder,
+                Size = AdaptiveTextSize.Large,
+                Wrap = true
             });
-            card.Body.Add(new AdaptiveTextBlock(GetDescriptionByLanguage(CardUtils.ENGLISH)));
+            card.Body.Add(new AdaptiveTextBlock(GetDescriptionByLanguage(CardUtils.ENGLISH))
+            {
+                Wrap = true
+            });
 
             return card;
         }

--- a/Store/IIdentifiable.cs
+++ b/Store/IIdentifiable.cs
@@ -2,11 +2,13 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Xml.Serialization;
 
 namespace CoreBot.Store
 {
     public abstract class IIdentifiable
     {
+        [XmlIgnore]
         public abstract int Id { get; set; }
     }
 }

--- a/Store/IPrestashopApi.cs
+++ b/Store/IPrestashopApi.cs
@@ -20,5 +20,8 @@ namespace CoreBot.Store
 
         [Get("/customers?display=[id,id_lang,passwd,lastname,firstname,email,company,date_upd]&filter[firstname]=%[{firstname}]%")]
         Task<CustomerCollection> GetCustomerByFirstName(string firstname);
+
+        [Get("/customers?display=[id,id_lang,passwd,lastname,firstname,email,company,date_upd]&filter[email]=%[{email}]%")]
+        Task<CustomerCollection> GetCustomerByEmail(string email);
     }
 }

--- a/Store/IPrestashopApi.cs
+++ b/Store/IPrestashopApi.cs
@@ -12,6 +12,9 @@ namespace CoreBot.Store
         [Get("/products?display=[id,name,description,id_default_image]&filter[id]={id}%")]
         Task<ProductCollection> GetProductById(int id);
 
+        [Get("/products?display=full")]
+        Task<ProductCollection> GetAllProducts();
+
         [Get("/customers?display=[id,id_lang,passwd,lastname,firstname,email,company,date_upd]&filter[id]={id}")]
         Task<CustomerCollection> GetCustomerById(int id);
 

--- a/Store/ImageCarouselable.cs
+++ b/Store/ImageCarouselable.cs
@@ -39,5 +39,27 @@ namespace CoreBot.Store
 
             return attachments.ToArray();
         }
+
+
+        public Attachment[] ToCarousel(IConfiguration configuration)
+        {
+            List<Attachment> attachments = new List<Attachment>();
+            Guid guid = Guid.NewGuid();
+
+            foreach (T element in Elements)
+            {
+                var card = element.ToImageAdaptiveCard(configuration);
+
+                var attachment = new Attachment
+                {
+                    Content = card,
+                    ContentType = "application/vnd.microsoft.card.adaptive"
+                };
+
+                attachments.Add(attachment);
+            }
+
+            return attachments.ToArray();
+        }
     }
 }

--- a/Store/ImageCarouselable.cs
+++ b/Store/ImageCarouselable.cs
@@ -16,17 +16,16 @@ namespace CoreBot.Store
     {
         public Attachment[] ToSelectionCarousel(IConfiguration configuration)
         {
-            int i = 0;
             List<Attachment> attachments = new List<Attachment>();
             Guid guid = Guid.NewGuid();
 
-            while (i < Elements.Length)
+            foreach(T element in Elements)
             {
-                var card = Elements[i].ToImageAdaptiveCard(configuration);
+                var card = element.ToImageAdaptiveCard(configuration);
                 card.Actions.Add(new AdaptiveSubmitAction
                 {
                     Title = "SELECT",
-                    DataJson = $@"{{ ""id"" : ""{guid.ToString()}"", ""action"" : ""{Elements[i].Id}""}}"
+                    DataJson = $@"{{ ""id"" : ""{guid.ToString()}"", ""action"" : ""{element.Id}""}}"
                 });
 
                 var attachment = new Attachment
@@ -36,7 +35,6 @@ namespace CoreBot.Store
                 };
 
                 attachments.Add(attachment);
-                i++;
             }
 
             return attachments.ToArray();


### PR DESCRIPTION
### New Controllers
Build Singleton Controllers which handle operations that would elsewhere require scoped services. These Controllers are injected in the dialogs and can be used directly without creating scoped contexts.

#### User Controller
Handles UserProfile operations such has:
- Retrieving an user by its Bot Id / Prestashop Id
- Adding Users to the Database
- Validating Users

#### Notify Controller
Sending diverse async notifications to users using BotCallBacks.
- Notifies superusers when a new user created a new account.
- Notifies users when their account has been validated.
- Notifies VITROSEP users when a customer required Technical Assistance.

#### Question Controller
- Adding questions to the Database.

### Improved welcoming conversation flow
Improved the welcoming conversation flow by modifying welcome texts (making them less robot-like and more sympathetic) and ensuring that eventhough the user may cancel all attempts to login or register it can be done by an alternative way.
- Created a welcoming card with some information to get started.
- Added alternative ways where the user can Login / Register / Ask for Validation manually on its own.

### Added the Login function
The welcome dialogflow branches into the Login Dialog if the user choses so, and may login using the same credentials as the VitrosepStore. The password is then checked between the two encrypting algorythms used and the login completes.

If the user is already validated the flow ends. If he's not, the user may send a message to a VITROSEP staff member in order to notify he wants to be validated. Once someone validates his account a user is sent a notification and may start using the service as a logged in user.

### Remodelled Permission Logic
The logic of user permission was too hard coded.
- Moved from const string to Enum types.
- Moved logic from `CancelAndHelpDialog` to its own `PermissionDialog`
- Added two extension methods to work with the Enum types.

### Added custom help messages with WaterfallSteps
Added a overridable function `ShowHelpAsync` that is able to show different messages when the user asks for help depending on the step we are inside the Dialog.

For example:

![image](https://user-images.githubusercontent.com/36483261/74230822-74cbc100-4cc5-11ea-8fb5-cae680b3f050.png)
When the bot asks for the Prestashop associated e-mail and user replies with "help" the help message will be adressing the current stage of the dialog (which is the asking e-mail step).
